### PR TITLE
[FIX] sale_order_type_automation: Fix auto_done_setting field

### DIFF
--- a/sale_order_type_automation/__manifest__.py
+++ b/sale_order_type_automation/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Sale Order Type Automation',
-    'version': '11.0.1.1.0',
+    'version': '11.0.1.2.0',
     'author': 'ADHOC SA',
     'website': 'www.adhoc.com.ar',
     'license': 'AGPL-3',

--- a/sale_order_type_automation/models/sale_order_type.py
+++ b/sale_order_type_automation/models/sale_order_type.py
@@ -4,6 +4,7 @@
 ##############################################################################
 from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError
+from odoo.tools.safe_eval import safe_eval
 
 
 class SaleOrderType(models.Model):
@@ -89,18 +90,15 @@ class SaleOrderType(models.Model):
         " sale order done instead of leaving it on"
         " 'sale order' state that allows modifications"
     )
-    auto_done_setting = fields.Selection([
-        (0, "Allow to edit sales order from the"
-         " 'Sales Order' menu (not from the Quotation menu)"),
-        (1, "Never allow to modify a confirmed sale order")],
+    auto_done_setting = fields.Boolean(
         compute='_compute_auto_done_setting',
     )
 
     @api.depends()
     def _compute_auto_done_setting(self):
         default = self.env['ir.config_parameter'].sudo().get_param(
-            'sale.auto_done_setting')
-        self.auto_done_setting = default
+            'sale.auto_done_setting', 'False')
+        self.auto_done_setting = safe_eval(default)
 
     @api.constrains(
         'payment_atomation',

--- a/sale_order_type_automation/views/sale_order_type_views.xml
+++ b/sale_order_type_automation/views/sale_order_type_views.xml
@@ -15,7 +15,7 @@
                 <field name="invoicing_atomation"/>
                 <field name="payment_atomation" attrs="{'invisible' : [('journal_id', '=', False)]}"/>
                 <field name="auto_done_setting" invisible="1"/>
-                <field name="set_done_on_confirmation" attrs="{'invisible' : [('auto_done_setting', '=', 1)]}"/>
+                <field name="set_done_on_confirmation" attrs="{'invisible' : [('auto_done_setting', '=', True)]}"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
9.0 odoo was a selection, now is a boolean