### PR TITLE
[FIX] sale_ux: field commercial_partner_id should be compute_related=…

### DIFF
--- a/sale_ux/models/sale_order.py
+++ b/sale_ux/models/sale_order.py
@@ -28,6 +28,7 @@ class SaleOrder(models.Model):
         related='partner_id.commercial_partner_id',
         store=True,
         readonly=True,
+        compute_sudo=True,
     )
 
     @api.onchange('pricelist_id')


### PR DESCRIPTION
…True

This is needed to fix the following problem: adding a partner to res_partner.child_ids will mark all element of child_ids as 'todo'
and trigger a write on res_parner.commercial_partner_id for all element of the child_ids and then on the related field
sale_order.commercial_partner_id. This can cause problem if partner in child_ids belong to different company and have sale orders. This will throw a
read access error when doing the _write method of sale_order. Adding the compute_related=True to sale_order.commercial_partner_id
ensure that the _write on that field is done in sudo.