### PR TITLE
[REL] sale_require_purchase_order_number: first release on 12.0

### DIFF
--- a/sale_require_purchase_order_number/README.rst
+++ b/sale_require_purchase_order_number/README.rst
@@ -14,11 +14,11 @@
 Sale Require Purchase Order Number
 ==================================
 
-This module Incorporate this:
+This module incorporates the following features:
 
-* Field "purchase order number" to sale order, picking and invoice.
-* Validate that the field is in these documents if the partner has the field "required number of PO". 
-* Purchase order number must be unique per partner
+* Field "purchase order number" on sale order, picking and invoice.
+* Validate that the field is in these documents if the partner has the field "required number of PO".
+* Purchase order number must be unique per partner.
 
 Installation
 ============
@@ -32,7 +32,7 @@ Configuration
 
 To configure this module, you need to:
 
-#. Set in the partner the boolean to required the "Purchase Order Number".
+#. Set in the partner the boolean to require the "Purchase Order Number".
 
 Usage
 =====

--- a/sale_require_purchase_order_number/__manifest__.py
+++ b/sale_require_purchase_order_number/__manifest__.py
@@ -39,7 +39,7 @@
     ],
     'demo': [
     ],
-    'installable': False,
+    'installable': True,
     'auto_install': False,
     'application': False,
 }

--- a/sale_require_purchase_order_number/models/account_invoice.py
+++ b/sale_require_purchase_order_number/models/account_invoice.py
@@ -12,7 +12,6 @@ class AccountInvoice(models.Model):
     require_purchase_order_number = fields.Boolean(
         string='Sale Require Origin',
         related='partner_id.require_purchase_order_number',
-        readonly=True,
     )
     purchase_order_number = fields.Char(
         readonly=True,
@@ -29,4 +28,4 @@ class AccountInvoice(models.Model):
             raise UserError(_(
                 'You cannot confirm invoice without a'
                 ' Purchase Order Number for this partner'))
-        return super(AccountInvoice, self).invoice_validate()
+        return super().invoice_validate()

--- a/sale_require_purchase_order_number/models/res_partner.py
+++ b/sale_require_purchase_order_number/models/res_partner.py
@@ -9,4 +9,6 @@ class ResPartner(models.Model):
     _inherit = "res.partner"
 
     require_purchase_order_number = fields.Boolean(
+        'Sale Require Origin',
+        help='Check this option to ask for an unique partner RFQ nbr. on SOs'
     )

--- a/sale_require_purchase_order_number/models/sale_order.py
+++ b/sale_require_purchase_order_number/models/sale_order.py
@@ -13,7 +13,6 @@ class SaleOrder(models.Model):
         string='Sale Require Origin',
         related='partner_id.require_purchase_order_number',
         help='If true, required purchase order number in sale order',
-        readonly=True,
     )
     purchase_order_number = fields.Char(
         copy=False
@@ -35,11 +34,11 @@ class SaleOrder(models.Model):
             raise UserError(_(
                 'You cannot confirm a sales order without a'
                 ' Purchase Order Number for this partner'))
-        return super(SaleOrder, self).action_confirm()
+        return super().action_confirm()
 
     @api.multi
     def _prepare_invoice(self):
-        invoice_vals = super(SaleOrder, self)._prepare_invoice()
+        invoice_vals = super()._prepare_invoice()
         invoice_vals.update({
             'purchase_order_number': self.purchase_order_number})
         return invoice_vals

--- a/sale_require_purchase_order_number/models/stock_picking.py
+++ b/sale_require_purchase_order_number/models/stock_picking.py
@@ -12,10 +12,9 @@ class StockPicking(models.Model):
     require_purchase_order_number = fields.Boolean(
         string='Sale Require Origin',
         related='partner_id.require_purchase_order_number',
-        readonly=True,
     )
     manual_purchase_order_number = fields.Char(
-        'Purchase Order Number',
+        'PO Number',
         states={'cancel': [('readonly', True)],
                 'done': [('readonly', True)]},
     )
@@ -48,4 +47,4 @@ class StockPicking(models.Model):
             raise UserError(_(
                 'You cannot transfer products without a Purchase'
                 ' Order Number for this partner'))
-        return super(StockPicking, self).action_done()
+        return super().action_done()

--- a/sale_require_purchase_order_number/views/res_partner_views.xml
+++ b/sale_require_purchase_order_number/views/res_partner_views.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <odoo>
     <record id="view_partner_form" model="ir.ui.view">
-        <field name="name">partner_form_view</field>
+        <field name="name">partner.form.view</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="arch" type="xml">
-            <field name="user_id" position="after">
+            <xpath expr="//page[@name='sales_purchases']//field[@name='user_id']" position="after">
                 <field name="require_purchase_order_number" attrs="{'invisible': [('customer', '!=', True)]}"/>
-            </field>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
- Improve README.
- Make installable.
- Write short supers.
- Improve 'require_purchase_order_number' field (add help and string).
- Remove default field for readonly attribute on related fields.
- Change partner form inherited view name to stick to Adhoc's guidelines.
- Change partner form inherited view form to allocate the user_id field, as now the field is twice, and the replacement is made on the second field (now we use an xpath).