### PR TITLE
[REL] sale_exception_price_security: first release on 12.0

### DIFF
--- a/sale_exception_price_security/__manifest__.py
+++ b/sale_exception_price_security/__manifest__.py
@@ -33,6 +33,6 @@
     ],
     'demo': [
     ],
-    'installable': False,
+    'installable': True,
     'auto_install': True,
 }

--- a/sale_exception_price_security/data/exception_rule_data.xml
+++ b/sale_exception_price_security/data/exception_rule_data.xml
@@ -5,7 +5,6 @@
       <field name="description">You can not give any discount greater than pricelist discounts or the applied discount is out of allowed range</field>
       <field name="sequence">10</field>
       <field name="model">sale.order.line</field>
-      <field name="rule_group">sale</field>
       <field name="code">if not object.check_discount_ok():
     failed = True</field>
       <field name="block_print" eval="True"/>


### PR DESCRIPTION
- Make installable.
- Remove "rule_group" field from data as it's no longer available.