### PR TITLE
[REL] sale_exception_partner_state: first release on 12.0

### DIFF
--- a/sale_exception_partner_state/README.rst
+++ b/sale_exception_partner_state/README.rst
@@ -14,7 +14,7 @@
 Sale Exception - Partner State Integration
 ==========================================
 
-Integrate partner_state and sale_exceptions, it adds the option to restrict sale orders confirmation for not approved partners globaly or depending a certain amount
+Integrate partner_state and sale_exceptions. It adds the option to restrict sale orders confirmation for not approved partners globaly or depending a certain amount.
 
 Installation
 ============
@@ -29,7 +29,7 @@ Configuration
 
 To configure this module, you need to:
 
-#. In Company/Configuration you set to restring sales.
+#. Go to Sales / Configuration / Settings / Quotations & Orders and set "Restrict sales?" as per your needs.
 
 
 Usage

--- a/sale_exception_partner_state/__manifest__.py
+++ b/sale_exception_partner_state/__manifest__.py
@@ -33,6 +33,6 @@
     ],
     'demo': [
     ],
-    'installable': False,
+    'installable': True,
     'auto_install': True,
 }

--- a/sale_exception_partner_state/data/exception_rule_data.xml
+++ b/sale_exception_partner_state/data/exception_rule_data.xml
@@ -6,7 +6,6 @@
     <field name="description">You can not sell to an Unapproved Partner on this company</field>
     <field name="sequence">10</field>
     <field name="model">sale.order</field>
-    <field name="rule_group">sale</field>
     <field name="code">if not object.check_unapproved_partner_ok():
     failed = True</field>
     <field name="active" eval="True"/>
@@ -17,7 +16,6 @@
     <field name="description">You can not sell to an Unapproved Partner this amount on this company</field>
     <field name="sequence">10</field>
     <field name="model">sale.order</field>
-    <field name="rule_group">sale</field>
     <field name="code">if not object.check_unapproved_partner_amount_ok():
     failed = True</field>
     <field name="active" eval="True"/>

--- a/sale_exception_partner_state/wizards/res_config_settings.py
+++ b/sale_exception_partner_state/wizards/res_config_settings.py
@@ -10,8 +10,10 @@ class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     restrict_sales = fields.Selection(
-        related='company_id.restrict_sales'
+        related='company_id.restrict_sales',
+        readonly=False,
     )
     restrict_sales_amount = fields.Float(
-        related='company_id.restrict_sales_amount'
+        related='company_id.restrict_sales_amount',
+        readonly=False,
     )


### PR DESCRIPTION
- Update README to actual version.
- Make installable.
- Remove field "rule_group" from rule data as it's deprecated.
- Add readonly=False attribute to restrict_sales and restrict_sales_amount as we need them to be editable, and now the default value for readonly is True.