### PR TITLE
[11.0] [IMP] sale_order_lot_selection_ux: Lots selection

### DIFF
--- a/sale_order_lot_selection_ux/models/sale_order_line.py
+++ b/sale_order_lot_selection_ux/models/sale_order_line.py
@@ -24,6 +24,8 @@ class SaleOrderLine(models.Model):
                 ('location_id', 'child_of', location.id),
                 ('quantity', '>', 0),
                 ('lot_id', '!=', False),
-            ], ['lot_id'], 'lot_id')
-            available_lot_ids = [quant['lot_id'][0] for quant in quants]
+            ], ['lot_id', 'reserved_quantity', 'quantity'], 'lot_id')
+            available_lot_ids = [
+                quant['lot_id'][0] for quant in quants
+                if quant['reserved_quantity'] < quant['quantity']]
             rec.available_lot_ids = available_lot_ids


### PR DESCRIPTION
To improve this, now only shows the lots that really have stock (avaliable stock)