### PR TITLE
[11.0] [FIX] sale_stock_availability: Be aware of the uom of sale order line.

### DIFF
--- a/sale_stock_availability/models/sale_order_line.py
+++ b/sale_stock_availability/models/sale_order_line.py
@@ -14,11 +14,14 @@ class SaleOrderLine(models.Model):
     )
 
     @api.depends(
+        'product_id',
         'product_uom_qty',
-        'product_id')
+        'product_uom')
     def _compute_virtual_available(self):
         for rec in self.filtered(
                 lambda sol: sol.order_id.state in ['draft', 'sent']):
-            rec.virtual_available = rec.product_id.with_context(
-                warehouse=rec.order_id.warehouse_id.id
-            ).virtual_available - rec.product_uom_qty
+            product_uom = rec.product_id.uom_id
+            virtual_available = rec.product_id.with_context(warehouse=rec.order_id.warehouse_id.id).virtual_available
+            if product_uom != rec.product_uom:
+                virtual_available = product_uom._compute_quantity(virtual_available, rec.product_uom)
+            rec.virtual_available = virtual_available - rec.product_uom_qty


### PR DESCRIPTION
If the uom selected in the order line is different than the uom of the product, convert units to the uom of the line.

**Ticket 30765**