### PR TITLE
[11.0] [FIX] sale_exception_credit_limit: Use the company currency to set the value for all the amounts

### DIFF
--- a/sale_exception_credit_limit/models/sale_order.py
+++ b/sale_exception_credit_limit/models/sale_order.py
@@ -40,7 +40,10 @@ class SaleOrder(models.Model):
                 price, line.order_id.currency_id,
                 not_invoiced,
                 product=line.product_id, partner=line.order_id.partner_id)
-            to_invoice_amount += taxes['total_included']
+            total = taxes['total_included']
+            if line.order_id.currency_id != line.company_id.currency_id:
+                total = line.order_id.currency_id.compute(taxes['total_included'], line.company_id.currency_id)
+            to_invoice_amount += total
 
         # We sum from all the invoices lines that are in draft and not linked
         # to a sale order
@@ -56,11 +59,17 @@ class SaleOrder(models.Model):
                 price, line.invoice_id.currency_id,
                 line.quantity,
                 product=line.product_id, partner=line.invoice_id.partner_id)
-            draft_invoice_lines_amount += taxes['total_included']
+            total = taxes['total_included']
+            if line.invoice_id.currency_id != line.company_id.currency_id:
+                total = line.invoice_id.currency_id.compute(taxes['total_included'], line.company_id.currency_id)
+            draft_invoice_lines_amount += total
 
         available_credit = self.partner_id.credit_limit - \
             self.partner_id.credit - \
             to_invoice_amount - draft_invoice_lines_amount
-        if self.amount_total > available_credit:
+        amount_total = self.amount_total
+        if self.currency_id != self.company_id.currency_id:
+            amount_total = self.currency_id.compute(self.amount_total, self.company_id.currency_id)
+        if amount_total > available_credit:
             return False
         return True


### PR DESCRIPTION
If you have several sales an invoices with different curency we need to set all values to the main currency of the company to compare the values.