### PR TITLE
[13.0] [FIX] sale_order_type_ux: Fix a bug when create and invoice from a SO with sale type.

### DIFF
--- a/sale_order_type_ux/models/account_move.py
+++ b/sale_order_type_ux/models/account_move.py
@@ -3,16 +3,11 @@
 # directory
 ##############################################################################
 
-from odoo import api, fields, models
+from odoo import api, models
 
 
 class AccountMove(models.Model):
     _inherit = 'account.move'
-
-    sale_type_id = fields.Many2one(
-        readonly=True,
-        states={'draft': [('readonly', False)]},
-    )
 
     @api.onchange('sale_type_id')
     def onchange_sale_type_id(self):


### PR DESCRIPTION
We remove the redefinition of the field sale_type_id because the field in v13 is computed and it's readonly=False by default, due this it's not necessary this change.
In addition, it causes the sale_type_id field in the invoice not to be completed.