### PR TITLE
[FIX] sale_exception_price_security: demo data load

### DIFF
--- a/sale_exception_price_security/__manifest__.py
+++ b/sale_exception_price_security/__manifest__.py
@@ -29,7 +29,6 @@
     ],
     'data': [
         'data/exception_rule_data.xml',
-        'security/sale_exception_price_security_security.xml',
     ],
     'demo': [
     ],

--- a/sale_exception_price_security/security/sale_exception_price_security_security.xml
+++ b/sale_exception_price_security/security/sale_exception_price_security_security.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <record id="price_security.group_restrict_prices" model="res.groups">
-        <field name="users" eval="[(4, ref('base.user_root'))]"/>
-    </record>
-</odoo>


### PR DESCRIPTION
if any module was installing demo data with discounts, the module would fail due to __system__ being add to restrict group