### PR TITLE
[13.0] [IMP] sale_order_type_automation: To consider if use automation with e-commerce.

### DIFF
--- a/sale_order_type_automation/models/sale_order.py
+++ b/sale_order_type_automation/models/sale_order.py
@@ -23,7 +23,12 @@ class SaleOrder(models.Model):
                     line.qty_to_invoice for line in rec.order_line):
                 _logger.warning('Noting to invoice')
                 continue
-
+            # we take into account if there are any transaction finish from the e-commerce
+            #  and not continue with the automation in this case
+            if self.transaction_ids and self.env['ir.config_parameter'].sudo().get_param('sale.automatic_invoice')\
+                and any(
+                    [True if transaction.state == 'done' else False for transaction in self.transaction_ids]):
+                continue
             # a list is returned but only one invoice should be returned
             # usamos final para que reste adelantos y tmb por ej
             # por si se usa el modulo de facturar las returns


### PR DESCRIPTION
**Ticket 36219**
If you configure the auto validation for the invoice and payment and the sale is coming from e-commerce, if the sale is already paid from an payment acquirer, we consider to skip this automation and continue with flow of the e-commerce payment and validation.