### PR TITLE
[FIX]sale_stock_ux: cancel remaining with no bom

### DIFF
--- a/sale_stock_ux/models/sale_order_line.py
+++ b/sale_stock_ux/models/sale_order_line.py
@@ -79,7 +79,7 @@ class SaleOrderLine(models.Model):
             if bom_enable:
                 bom = self.env['mrp.bom']._bom_find(
                     product=rec.product_id)
-                if bom.type == 'phantom':
+                if bom and bom.type == 'phantom':
                     raise UserError(_(
                         "Cancel remaining can't be called for Kit Products "
                         "(products with a bom of type kit)."))


### PR DESCRIPTION
if the product has no bom, the user error of products with
a bom of type  kit is not correct