### PR TITLE
[13.0] [FIX] sale_order_type_user_default: Save the value that you setting in.

### DIFF
--- a/sale_order_type_user_default/models/sale_order.py
+++ b/sale_order_type_user_default/models/sale_order.py
@@ -12,7 +12,7 @@ class SaleOrder(models.Model):
     def _compute_sale_type_id(self):
         sales = self.env['sale.order']
         user_type = self.env.user.default_sale_order_type_id
-        if user_type:
+        if user_type and isinstance(self.id, models.NewId):
             for rec in self:
                 # use default user type if:
                 # 1. type dont have company or is same as sale order


### PR DESCRIPTION

Before that changes the field for user default value for the user is saving , although you select a different value after this was is setting.
We need to only show this value (user default) when create and if you change it when save the record the value keep the same that the user choose, not the default value.