### PR TITLE
[FIX]13.0 sale_order_type_invoice_policy: credit notes

### DIFF
--- a/sale_order_type_invoice_policy/models/stock_picking.py
+++ b/sale_order_type_invoice_policy/models/stock_picking.py
@@ -43,7 +43,7 @@ class StockPicking(models.Model):
         precision = self.env['decimal.precision'].precision_get(
             'Product Unit of Measure')
         invoice_status = self.sale_id.mapped(
-            'order_line.invoice_lines.move_id.invoice_payment_state')
+            'order_line.invoice_lines.move_id').filtered(lambda x: x.type == 'out_invoice').mapped('invoice_payment_state')
         if (set(invoice_status) - set(['paid'])) or any(
                 not float_is_zero(line.qty_to_invoice, precision_digits=precision)
                 for line in self.sale_id.order_line):


### PR DESCRIPTION
Credit notes associated to a sale not taken into account when validating a picking, if invoice policy is set as "Prepaid - Block Delivery".