### PR TITLE
[IMP] sale_order_type_ux: analytic_tag_ids relocated on sale_order_type_form_view

### DIFF
--- a/sale_order_type_ux/__manifest__.py
+++ b/sale_order_type_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Sale Order Type Ux',
-    'version': "15.0.1.0.0",
+    'version': "15.0.1.1.0",
     'category': 'Accounting',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/sale_order_type_ux/models/sale_order_type.py
+++ b/sale_order_type_ux/models/sale_order_type.py
@@ -26,11 +26,8 @@ class SaleOrderTypology(models.Model):
     )
 
     analytic_account_id = fields.Many2one(
-        'account.analytic.account',
         copy=False,
-        check_company=True,
         domain="['|' , ('company_id', '=', False), ('company_id', '=', company_id)]",
-        help="Default analytic account that will be used on new sale order"
         )
 
     active = fields.Boolean(

--- a/sale_order_type_ux/views/sale_order_type_views.xml
+++ b/sale_order_type_ux/views/sale_order_type_views.xml
@@ -15,8 +15,7 @@
         <field name="model">sale.order.type</field>
         <field name="inherit_id" ref="sale_order_type.sot_sale_order_type_form_view"/>
         <field name="arch" type="xml">
-            <field name="incoterm_id" position="after">
-                <field name="analytic_account_id" groups="analytic.group_analytic_accounting"/>
+            <field name="analytic_account_id" position="after">
                 <field name="analytic_tag_ids" widget="many2many_tags" groups="analytic.group_analytic_tags"/>
             </field>
             <field name="payment_term_id" position="after">


### PR DESCRIPTION
This relocates analytic_tag_ids below analytic_account_id. Additionally, removes redundant lines in sale_order_type.