### PR TITLE
[FIX] sale_exception_credit_limit: credit taken consideration

### DIFF
--- a/sale_exception_credit_limit/__manifest__.py
+++ b/sale_exception_credit_limit/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Sale Exception Credit Limit',
-    'version': "16.0.1.1.0",
+    'version': "16.0.1.2.0",
     'author': 'ADHOC SA',
     'website': 'www.adhoc.com.ar',
     'license': 'AGPL-3',

--- a/sale_exception_credit_limit/models/res_partner.py
+++ b/sale_exception_credit_limit/models/res_partner.py
@@ -60,7 +60,8 @@ class ResPartner(models.Model):
                     ('move_id.partner_id.commercial_partner_id', '=', self.commercial_partner_id.id),
                     ('move_id.move_type', 'in', ['out_invoice', 'out_refund']),
                     ('move_id.state', '=', 'draft'),
-                    ('sale_line_ids', '=', False)]
+                    '|',('sale_line_ids', '=', False),
+                    ('sale_line_ids.order_id.invoice_status', '=', 'invoiced')]
             draft_invoice_lines = self.env['account.move.line'].search(domain)
             draft_invoice_lines_amount = 0.0
             for line in draft_invoice_lines:


### PR DESCRIPTION
It was not counting draft invoices if they had a sale order linked. Also happened with downpayments.