### PR TITLE
[IMP] sale_order_type_automation: types without company

### DIFF
--- a/sale_order_type_automation/demo/sale_order_type_demo.xml
+++ b/sale_order_type_automation/demo/sale_order_type_demo.xml
@@ -3,18 +3,22 @@
     <record id="sale_order_type_create_invoice_automation" model="sale.order.type">
         <field name="name">Invoice Automation (Create)</field>
         <field name="invoicing_atomation">create_invoice</field>
+        <field name="company_id" eval="False"/>
     </record>
     <record id="sale_order_type_validate_invoice_automation" model="sale.order.type">
         <field name="name">Invoice Automation (Validate)</field>
         <field name="invoicing_atomation">validate_invoice</field>
+        <field name="company_id" eval="False"/>
     </record>
     <record id="sale_order_type_validate_picking_automation" model="sale.order.type">
         <field name="name">Picking Automation (Validate)</field>
         <field name="picking_atomation">validate</field>
+        <field name="company_id" eval="False"/>
     </record>
     <record id="sale_order_type_validate_picking_and_invoice_automation" model="sale.order.type">
         <field name="name">Picking And Invoice Automation (Validate)</field>
         <field name="picking_atomation">validate</field>
         <field name="invoicing_atomation">validate_invoice</field>
+        <field name="company_id" eval="False"/>
     </record>
 </odoo>


### PR DESCRIPTION
Esto es por dos motivos:
a) para evitar error al duplicar ventas con demo_base que termina haciendo (por error) que encuentre uno de estos types que tenían compañías b) al hacer que no tengan, la data demo esta compartida con todas las cias