### PR TITLE
[IMP] _type_automation: add sequence to avoid demo data used by default

### DIFF
--- a/sale_order_type_automation/demo/sale_order_type_demo.xml
+++ b/sale_order_type_automation/demo/sale_order_type_demo.xml
@@ -4,21 +4,25 @@
         <field name="name">Invoice Automation (Create)</field>
         <field name="invoicing_atomation">create_invoice</field>
         <field name="company_id" eval="False"/>
+        <field name="sequence" eval="15"/>
     </record>
     <record id="sale_order_type_validate_invoice_automation" model="sale.order.type">
         <field name="name">Invoice Automation (Validate)</field>
         <field name="invoicing_atomation">validate_invoice</field>
         <field name="company_id" eval="False"/>
+        <field name="sequence" eval="15"/>
     </record>
     <record id="sale_order_type_validate_picking_automation" model="sale.order.type">
         <field name="name">Picking Automation (Validate)</field>
         <field name="picking_atomation">validate</field>
         <field name="company_id" eval="False"/>
+        <field name="sequence" eval="15"/>
     </record>
     <record id="sale_order_type_validate_picking_and_invoice_automation" model="sale.order.type">
         <field name="name">Picking And Invoice Automation (Validate)</field>
         <field name="picking_atomation">validate</field>
         <field name="invoicing_atomation">validate_invoice</field>
         <field name="company_id" eval="False"/>
+        <field name="sequence" eval="15"/>
     </record>
 </odoo>


### PR DESCRIPTION
Cuando usamos los modulos demo y duplicamos ventas, se eligen estos types con automation que mandan a crear y validar facturas lo cual algunas veces se termina rompiendo (por ej. por localización uruguaya). Preferimos dejarlo mas parecido a la demo data por defecto donde no hay type automation