### PR TITLE
[IMP] _type_invoice_policy: default data shared and lower sequence

### DIFF
--- a/sale_order_type_invoice_policy/__manifest__.py
+++ b/sale_order_type_invoice_policy/__manifest__.py
@@ -26,7 +26,7 @@
     'license': 'AGPL-3',
     'depends': [
         'account',
-        'sale_order_type',
+        'sale_order_type_ux',
         # agregamos esta depenencia para permitir reembolsar las devoluciones
         # y para no tener que hacer modulos puente
         'sale_stock_ux',

--- a/sale_order_type_invoice_policy/data/sale_order_type_data.xml
+++ b/sale_order_type_invoice_policy/data/sale_order_type_data.xml
@@ -2,10 +2,14 @@
     <record id="prepaid_sale_type" model="sale.order.type">
         <field name="name">Pre Paid</field>
         <field name="invoice_policy">prepaid</field>
+        <field name="company_id" eval="False"/>
+        <field name="sequence" eval="15"/>
     </record>
 
         <record id="ordered_sale_type" model="sale.order.type">
         <field name="name">Ordered quantities</field>
         <field name="invoice_policy">order</field>
+        <field name="company_id" eval="False"/>
+        <field name="sequence" eval="15"/>
     </record>
 </odoo>


### PR DESCRIPTION
Cambiamos la adta demo para que  por defecto se use el normal type y ademas para que sea compartida entre varias compañías Esto nos resuelve errores en demo builds como esta https://runbot.adhoc.com.ar/runbot/build/30836 pero ademas mejora la experiencia para clientes ya que por defecto pueden utilizar en distintas compañías estos tipos.

Como tiene no update no rompe a ningun cliente existente