### PR TITLE
[FIX] sale_ux: send null company when creating analytical account

### DIFF
--- a/sale_ux/models/sale_order.py
+++ b/sale_ux/models/sale_order.py
@@ -243,6 +243,7 @@ class SaleOrder(models.Model):
             return {
                 'name': name,
                 'code': self.client_order_ref,
+                'company_id': False,
                 'plan_id': plan.id,
                 'partner_id': self.partner_id.id,
             }


### PR DESCRIPTION
I copy the same from here: [link](https://github.com/ingadhoc/sale/blob/b30d13245b543b9d8873cd3ceee5089c0b17188a/sale_ux/models/sale_order.py#L219)