### PR TITLE
[FIX] sale_ux: crear factura desde suscripción

### DIFF
--- a/sale_ux/models/sale_order.py
+++ b/sale_ux/models/sale_order.py
@@ -212,7 +212,7 @@ class SaleOrder(models.Model):
             lambda i: float_is_zero(i.amount_total, precision_digits=precision) and all(
                 [line.quantity <= 0.0 for line in i.invoice_line_ids])
         )
-        filtered_invoices.action_switch_invoice_into_refund_credit_note()
+        filtered_invoices.action_switch_move_type()
         filtered_invoices.invoice_line_ids.write({'quantity': abs(line.quantity) for line in filtered_invoices.invoice_line_ids})
         return invoices
 


### PR DESCRIPTION
Ticket: 73755
Al crear factura regular desde el botón de crear factura en una suscripción se obtiene el siguiente error que se arregla en este pr: RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/http.py", line 1768, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/http.py", line 1795, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/http.py", line 1999, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/data/build/adhoc-cicd-odoo-odoo/addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/addons/base/models/ir_http.py", line 222, in _dispatch
    result = endpoint(**request.params)
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/http.py", line 725, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/data/build/adhoc-cicd-odoo-odoo/addons/web/controllers/dataset.py", line 28, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/data/build/adhoc-cicd-odoo-odoo/addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/api.py", line 468, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/data/build/adhoc-cicd-odoo-odoo/addons/sale/wizard/sale_make_invoice_advance.py", line 180, in create_invoices
    invoices = self._create_invoices(self.sale_order_ids)
  File "/data/build/adhoc-cicd-odoo-odoo/addons/sale_timesheet/wizard/sale_make_invoice_advance.py", line 51, in _create_invoices
    return super()._create_invoices(sale_orders)
  File "/data/build/adhoc-cicd-odoo-enterprise/sale_subscription/wizard/sale_make_invoice_advance.py", line 28, in _create_invoices
    invoices = super(SaleAdvancePaymentInv, self)._create_invoices(sale_orders)
  File "/data/build/adhoc-cicd-odoo-odoo/addons/sale/wizard/sale_make_invoice_advance.py", line 198, in _create_invoices
    return sale_orders._create_invoices(final=self.deduct_down_payments, grouped=not self.consolidated_billing)
  File "/data/build/adhoc-cicd-odoo-odoo/addons/sale_timesheet/models/sale_order.py", line 145, in _create_invoices
    moves = super()._create_invoices(grouped=grouped, final=final, date=date)
  File "/data/build/adhoc-cicd-odoo-enterprise/sale_subscription_external_tax/models/sale_subscription.py", line 19, in _create_invoices
    moves = super()._create_invoices(grouped=grouped, final=final, date=date)
  File "/data/build/ingadhoc-sale/sale_ux/models/sale_order.py", line 215, in _create_invoices
    filtered_invoices.action_switch_invoice_into_refund_credit_note()
AttributeError: 'account.move' object has no attribute 'action_switch_invoice_into_refund_credit_note'

The above server error caused the following client error: RPC_ERROR: Odoo Server Error
    at makeErrorFromResponse (https://50243-17-0-all.runbot.adhoc.com.ar/web/assets/1/a0a05c2/web.assets_web.min.js:2870:163)
    at XMLHttpRequest.<anonymous> (https://50243-17-0-all.runbot.adhoc.com.ar/web/assets/1/a0a05c2/web.assets_web.min.js:2874:13)