### PR TITLE
[FIX] sale_three_discount: problems with discount and inverse method

### DIFF
--- a/sale_three_discounts/models/sale_order_line.py
+++ b/sale_three_discounts/models/sale_order_line.py
@@ -76,11 +76,14 @@ class SaleOrderLine(models.Model):
                 if 'discount3' in vals and vals.get('discount3') == 0:
                     vals.pop('discount3')
             precision = self.env['decimal.precision'].precision_get('Discount')
-            if 'discount' in vals \
-                    and not {'discount1', 'discount2', 'discount3'} & set(vals.keys()):
-                vals.update({
-                    'discount1': vals.get('discount'),
-                })
+            for rec in self:
+                if 'discount' in vals and float_compare(vals.get('discount'), rec.discount, precision_digits=precision) != 0 \
+                        and not {'discount1', 'discount2', 'discount3'} & set(vals.keys()):
+                    vals.update({
+                        'discount1': vals.get('discount'),
+                        'discount2': 0,
+                        'discount3': 0,
+                    })
 
     @api.depends('discount1', 'discount2', 'discount3')
     def _compute_discounts(self):


### PR DESCRIPTION
Agregamos float compare porque al agregar en descuento 1 43% y descuento 2 15% el cálculo da muchos decimales y la vista capta que existe un cambio en los descuentos y los reevalua incorporando más descuento que el debido. 