### PR TITLE
[REF] sale_order_type_automation: switch from warning to info to be able to merge tests

### DIFF
--- a/sale_order_type_automation/models/sale_order.py
+++ b/sale_order_type_automation/models/sale_order.py
@@ -21,7 +21,7 @@ class SaleOrder(models.Model):
             # an error
             if not any(
                     line.qty_to_invoice for line in rec.order_line):
-                _logger.warning('Noting to invoice')
+                _logger.info('Nothing to invoice')
                 continue
             # we take into account if there are any transaction finish from the e-commerce
             #  and not continue with the automation in this case


### PR DESCRIPTION
Cuando el tipo de venta valida el picking y la factura, ingresa dos veces al método run_invoicing_atomation y en la segunda al ya estar facturado entra si o si al warning, esto hace que nos de error la build de los prs de test por este warning y no podemos mezclar. Deberíamos corregir para que no entre dos veces en el método, pero para no hacer ruido en la versión estable de 16 lo vamos a ver en 17 y lo evitamos cambiando de warning a info.