### PR TITLE
[FIX] sale_gathering: stepping on invoiced quantity in gathering orders

### DIFF
--- a/sale_gathering/models/sale_order_line.py
+++ b/sale_gathering/models/sale_order_line.py
@@ -56,3 +56,8 @@ class SaleOrderLine(models.Model):
                     and rec.discount > 0
                 ):
                     raise ValidationError(_("Cannot add discounts to redeemed products."))
+
+    def _compute_qty_invoiced(self):
+        super()._compute_qty_invoiced()
+        for line in self.filtered(lambda x: x.order_id.is_gathering and x.qty_invoiced < 0 and x.is_downpayment):
+            line.qty_invoiced = 0


### PR DESCRIPTION
Hacemos esto por compatibilidad con invoice policy "preago -x" que actualmente verifica que la cantidad a facturar sea 0 y bloque entregas.

Más adelante queremos ver si hacemos un refactor donde amos bajando el anticipo en cantidades propocionales al consumo del acopia