### PR TITLE
[FIX] portal_sale_distributor: added domain by mistake for those who …

### DIFF
--- a/portal_sale_distributor/__manifest__.py
+++ b/portal_sale_distributor/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Portal Distributor Sale',
-    'version': "17.0.1.3.0",
+    'version': "17.0.1.4.0",
     'category': 'Tools',
     'complexity': 'easy',
     'author': 'ADHOC SA, Odoo Community Association (OCA)',

--- a/portal_sale_distributor/views/product_product_views.xml
+++ b/portal_sale_distributor/views/product_product_views.xml
@@ -31,4 +31,14 @@
             </field>
         </field>
     </record>
+    <record id="product_normal_form_view" model="ir.ui.view">
+        <field name="name">product.product.form</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view"/>
+        <field name="arch" type="xml">
+            <field name="additional_product_tag_ids" position="attributes">
+                <attribute name="groups">!portal_sale_distributor.group_portal_backend_distributor</attribute>
+            </field>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
…are not part of the portal distributor group

Como additional_product_tag_ids tiene el siguiente dominio domain="[('id', 'not in', product_tag_ids)]"
Y como product_tag_ids tiene el groups !portal_sale_distributor.group_portal_backend_distributor 
Debemos agregar el mismo groups a additional_product_tag_ids