### PR TITLE
[FIX] sale_gathering: take into account amounts delivered in gatherin…

### DIFF
--- a/sale_gathering/models/sale_order.py
+++ b/sale_gathering/models/sale_order.py
@@ -30,6 +30,7 @@ class SaleOrder(models.Model):
         'order_line.qty_invoiced',
         'order_line.qty_to_invoice',
         'order_line.is_downpayment',
+        'order_line.qty_to_deliver',
         'state'
     )
     def _compute_gathering_balance(self):
@@ -48,7 +49,11 @@ class SaleOrder(models.Model):
             tax_totals = order.env['account.tax']._compute_taxes([
                 {
                     **line._convert_to_tax_base_line_dict(),
-                    'quantity': line.qty_to_invoice + line.qty_invoiced
+                    'quantity': (
+                        line.qty_to_invoice + line.qty_invoiced + line.qty_to_deliver
+                        if line.product_id.invoice_policy == 'delivery' else
+                        line.qty_to_invoice + line.qty_invoiced
+                    )
                 }
                 for line in order_lines
             ])


### PR DESCRIPTION
…g balance


No se calculaba el balance de acopio en los productos con política de facturación cantidades entregadas cuando aumentábamos la cantidad, solo lo hacía después de facturar. Ahora al aumentar la cantidad de producto con esa política de facturación se computa bien