### PR TITLE
[FIX] sale_gathering: change in action done

### DIFF
--- a/sale_gathering/i18n/es.po
+++ b/sale_gathering/i18n/es.po
@@ -203,13 +203,6 @@ msgstr ""
 
 #. module: sale_gathering
 #. odoo-python
-#: code:addons/sale_gathering/models/sale_order.py:0
-#, python-format
-msgid "You can't add more products. First create the gathering invoice."
-msgstr "No puedes añadir más productos. Primero crea la factura de acopio."
-
-#. module: sale_gathering
-#. odoo-python
 #: code:addons/sale_gathering/models/sale_order_line.py:0
 #, python-format
 msgid ""

--- a/sale_gathering/wizards/sale_advance_payment_inv.py
+++ b/sale_gathering/wizards/sale_advance_payment_inv.py
@@ -13,13 +13,6 @@ class SaleAdvancePaymentInvWizard(models.TransientModel):
         ondelete={'invoice_gathering_zero': 'cascade'},
     )
 
-
-    def _prepare_so_line(self, order, analytic_tag_ids, tax_ids, amount):
-        result = super()._prepare_so_line(order, analytic_tag_ids, tax_ids, amount)
-        result['sequence'] = 0
-        return result
-
-
     def create_invoices(self):
         sale_orders = self.env['sale.order'].browse(self._context.get('active_ids', []))
         if self.advance_payment_method == 'invoice_gathering_zero':


### PR DESCRIPTION
No es necesario _check_gathering_order_line ya que la restricción está en otro lado https://github.com/ingadhoc/sale/blob/115b3be181ac3f030f0f25196cca3466c6bda0ab/sale_gathering/models/sale_order_line.py#L93

action_done no existe más en 17 y es action_locked

_prepare_so_line no existe más