### PR TITLE
[FIX] sale_order_validity: fix in sale order form view

### DIFF
--- a/sale_order_validity/__manifest__.py
+++ b/sale_order_validity/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Sale Order Validity',
-    'version': "18.0.1.0.0",
+    'version': "18.0.1.1.0",
     'category': 'Sales & Purchases',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/sale_order_validity/views/sale_order_view.xml
+++ b/sale_order_validity/views/sale_order_view.xml
@@ -29,6 +29,10 @@
                     invisible="state not in ['draft', 'sent']"/>
                 </div>
             </field>
+            <xpath expr="//div[hasclass('o_td_label') and @groups='base.group_no_one']" position="attributes">
+                <!-- Eliminamos el atributo 'groups' -->
+                <attribute name="groups"/>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
When sale_subscription_ux is installed and the developer mode is disabled the sale order form view in subscriptions the view gets disordered. This PR delete de developer group from the view