### PR TITLE
[FIX] sale_order_type_automation and _stock_voucher: picking refactoring

### DIFF
--- a/sale_order_type_automation/models/sale_order.py
+++ b/sale_order_type_automation/models/sale_order.py
@@ -48,61 +48,57 @@ class SaleOrder(models.Model):
                     invoices.message_post(body=message)
                     rec.message_post(body=message)
 
-    def run_picking_atomation(self):
+    def run_picking_automation(self):
         # If there products are the type 'service' equals the
         #  delivered qyt to order qty for this sale order line
-        for order_lines in self.mapped('order_line').filtered(
-            lambda x: x.order_id.type_id.picking_atomation !=
-            'none' and x.product_id.type ==
-            'service' and x.product_id.service_type ==
-                'manual' and x.product_id.expense_policy == 'no'):
-            order_lines.qty_delivered = order_lines.product_uom_qty
+        for order_line in self.mapped('order_line').filtered(
+            lambda x: x.order_id.type_id.picking_atomation != 'none'
+            and x.product_id.type == 'service'
+            and x.product_id.service_type == 'manual'
+            and x.product_id.expense_policy == 'no'
+        ):
+            order_line.qty_delivered = order_line.product_uom_qty
         for rec in self.filtered(
-                lambda x: x.type_id.picking_atomation != 'none' and
-                x.procurement_group_id):
-            jit_installed = self.env['ir.module.module'].search(
-                [('name', '=', 'procurement_jit'),
-                    ('state', '=', 'installed')], limit=1)
-            stock_voucher_installed = self.env['ir.module.module'].search(
-                [('name', '=', 'stock_voucher'),
-                    ('state', '=', 'installed')], limit=1)
-            # we add invalidate because on boggio we have add an option
-            # for tracking_disable and with that setup pickings where not seen
-            # rec.invalidate_cache()
+            lambda x: x.type_id.picking_atomation != 'none'
+            and x.procurement_group_id
+        ):
             pickings = rec.picking_ids.filtered(
-                lambda x: x.state not in ('done', 'cancel'))
-            if not jit_installed:
-                pickings.action_assign()
-            # ordenamos primeros los pickings asignados y luego el resto
-            assigned_pickings = pickings.filtered(
-                lambda x: x.state == 'assigned')
-            pickings = assigned_pickings + (pickings - assigned_pickings)
-            for pick in pickings:
-                if rec.type_id.picking_atomation == 'validate':
-                    # this method already call action_assign
-                    pick.new_force_availability()
-                elif rec.type_id.picking_atomation == 'validate_no_force':
-                    products = []
-                    for move in pick.mapped('move_ids'):
-                        if move.state != 'assigned':
-                            products.append(move.product_id)
-                    if products:
-                        raise UserError(_(
-                            'The following products are not available, we '
-                            'suggest to check stock or to use a sale type that'
-                            'force availability.\nProducts:\n* %s\n'
-                        ) % ('\n * '.join(x.name for x in products)))
-                    for op in pick.mapped('move_line_ids'):
-                        op.quantity = op.quantity_product_uom
-                if not stock_voucher_installed:
-                    pick.button_validate()
+                lambda x: x.state not in ('done', 'cancel')
+            )
+            pickings.action_assign()
+            pickings = pickings.sorted(
+                key=lambda x: (x.state != 'assigned', x.id)
+            )
+            self._process_pickings(pickings, rec)
+        return True
+
+    def _process_pickings(self, pickings, rec):
+        products = []
+        for pick in pickings:
+            if rec.type_id.picking_atomation == 'validate':
+                pick.new_force_availability()
+            elif rec.type_id.picking_atomation == 'validate_no_force':
+                products.extend(
+                    move.product_id for move in pick.move_ids if move.state != 'assigned'
+                )
+                if products:
+                    raise UserError(_(
+                        'The following products are not available, we '
+                        'suggest to check stock or to use a sale type that'
+                        'force availability.\nProducts:\n* %s\n'
+                    ) % '\n* '.join(x.name for x in products))
+
+                for op in pick.move_line_ids:
+                    op.quantity = op.quantity_product_uom
+
+            pick.button_validate()
 
     def action_confirm(self):
         res = super().action_confirm()
         # we use this because compatibility with sale exception module
         if isinstance(res, bool) and res:
             # because it's needed to return actions if exists
-            self.run_picking_atomation()
+            res = self.run_picking_automation()
             self.sudo().run_invoicing_atomation()
             if self.type_id.set_done_on_confirmation:
                 self.action_lock()

--- a/sale_order_type_automation_stock_voucher/README.rst
+++ b/sale_order_type_automation_stock_voucher/README.rst
@@ -10,9 +10,9 @@
    :target: https://www.gnu.org/licenses/agpl
    :alt: License: AGPL-3
 
-=================================================
-Website Sale Hide All Prices Product Configurator
-=================================================
+========================================
+Sale Order Type Automation Stock Voucher
+========================================
 
 This module integrate Sale Order Type Automation and Stock Voucher.
 

--- a/sale_order_type_automation_stock_voucher/__manifest__.py
+++ b/sale_order_type_automation_stock_voucher/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Sale Order Type Automation Stock Voucher',
-    'version': "17.0.1.0.0",
+    'version': "17.0.1.1.0",
     'author': 'ADHOC SA',
     'website': 'www.adhoc.com.ar',
     'license': 'AGPL-3',

--- a/sale_order_type_automation_stock_voucher/models/sale_order.py
+++ b/sale_order_type_automation_stock_voucher/models/sale_order.py
@@ -2,41 +2,26 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import models, _
-from odoo.exceptions import UserError
+from odoo import models
 
 
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
-    def assign_book_id(self):
-        for rec in self.filtered(
-                lambda x: x.type_id.picking_atomation != 'none' and
-                x.procurement_group_id):
-            pickings = rec.picking_ids.filtered(
-                lambda x: x.state not in ('done', 'cancel'))
-            if rec.type_id.book_id:
-                pickings.write({'book_id': rec.type_id.book_id.id})
-            # because of ensure_one on delivery module
-            actions = []
-            for pick in pickings:
-                # append action records to print the reports of the pickings
-                #  involves
-                if pick.book_required:
-                    actions.append(pick.do_print_voucher())
-                pick.button_validate()
-            if actions:
-                return {
-                    'actions': actions,
-                    'type': 'ir.actions.act_multi',
-                }
-            else:
-                return True
+    def _process_pickings(self, pickings, rec):
+        if rec.type_id.book_id:
+            pickings.write({'book_id': rec.type_id.book_id.id})
+        super()._process_pickings(pickings, rec)
 
-    def action_confirm(self):
-        res = super().action_confirm()
-        # we use this because compatibility with sale exception module
-        if isinstance(res, bool) and res:
-            # because it's needed to return actions if exists
-            res = self.assign_book_id()
+    def run_picking_automation(self):
+        res = super().run_picking_automation()
+        pickings_book_required = self.picking_ids.filtered("book_required")
+        if pickings_book_required:
+            actions = [pick.do_print_voucher() for pick in pickings_book_required]
+            # it is required to update sale order view
+            actions.append({'type': 'ir.actions.client', 'tag': 'soft_reload'})
+            return {
+                'type': 'ir.actions.act_multi',
+                'actions': actions,
+            }
         return res


### PR DESCRIPTION
Refactorización sale_order_type_automation para hacerlo heredable y se cambia lo siguiente:
- Necesitamos ordenar también por ID a los pickings debido a que si es una entrega en 3 pasos necesitamos que se haga en orden. El primer elemento (x.state != 'assigned') prioriza los pickings asignados, ya que False (asignados) se evalúa antes que True (no asignados). El segundo elemento (x.id) ordena los pickings dentro de cada grupo por ID en orden ascendente.
- Agrego método extra _process_pickings para heredarlo desde otros módulos
- Agrego el res = run_picking_automation() ya que quizás necesitemos devolver una acción lo podemos hacer con eso pisando el return que viene

Refactorización sale_order_type_automation_stock_voucher para utilizar los métodos heredables anteriores y se cambia lo siguiente:
- No vuelvo a recorrer el for (como se hacía antes de este cambio) ya que utilizo el _process_picking
- Antes de agregar nuevo método puedo reutilizar el run_picking_automation para devolver las acciones de impresión de voucher
- Anexo al punto anterior necesité agregar soft_reload para actualizar la SO ya que sino quedaba sin recargar los nuevos datos y parecía que no se hubiera confirmado (bug)