### PR TITLE
[FIX] sale_order_type_ux: the product_id field no longer exists

### DIFF
--- a/sale_gathering/models/account_move.py
+++ b/sale_gathering/models/account_move.py
@@ -5,15 +5,22 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     def action_post(self):
-        down_payment_line = self.line_ids.filtered(
+        down_payment_lines = self.line_ids.filtered(
             lambda line: line.is_downpayment and line.sale_line_ids.order_id.is_gathering
         )
-        if down_payment_line:
-            tax_id = down_payment_line.sale_line_ids.tax_id
-            price_unit = down_payment_line.sale_line_ids.price_unit
-        res = super(AccountMove, self).action_post()
-        if down_payment_line:
-            for line in down_payment_line:
-                line.sale_line_ids.tax_id = tax_id
-                line.sale_line_ids.price_unit = price_unit
+
+        sale_lines_data = []
+        for move_line in down_payment_lines:
+            for sale_line in move_line.sale_line_ids:
+                sale_lines_data.append((sale_line, sale_line.tax_id, sale_line.price_unit))
+
+        res = super().action_post()
+
+        for sale_line, tax_id, price_unit in sale_lines_data:
+            sale_line.write(
+                {
+                    "tax_id": tax_id,
+                    "price_unit": price_unit,
+                }
+            )
         return res

--- a/sale_order_type_ux/wizards/sale_advance_payment_inv.py
+++ b/sale_order_type_ux/wizards/sale_advance_payment_inv.py
@@ -17,12 +17,16 @@ class SaleAdvancePaymentInv(models.TransientModel):
         company = order.type_id.journal_id.company_id
         self = self.with_company(company.id)
         res = super()._prepare_invoice_values(order, so_line, accounts)
-        if company != order.company_id.id:
-            taxes = self.product_id.taxes_id.filtered(lambda r: not order.company_id or r.company_id == company)
-            if order.fiscal_position_id and taxes:
-                tax_ids = order.fiscal_position_id.map_tax(taxes).ids
-            else:
-                tax_ids = taxes.ids
-            res["invoice_line_ids"][0][2]["tax_ids"] = [(6, 0, tax_ids)]
+        if company != order.company_id:
+            for line_downpayment in so_line.filtered("is_downpayment"):
+                tax = line_downpayment.tax_id
+                if order.fiscal_position_id and tax:
+                    tax_ids = order.fiscal_position_id.map_tax(tax).ids
+                else:
+                    tax_ids = tax.ids
+
+                for line in res["invoice_line_ids"]:
+                    if line[2]["is_downpayment"] and line[2]["sale_line_ids"][0][1] == line_downpayment.id:
+                        line[2]["tax_ids"] = [(6, 0, tax_ids)]
 
         return res


### PR DESCRIPTION
No existe más el campo product_id en el modelo sale.advance.payment.inv, commit: https://github.com/odoo/odoo/commit/9aa52dd6418e5881adc2d96d15d062b55d6150c5

Ahora lo que antes era un producto de anticipo ahora en v18 ya no es más un producto en si, sino se pone simplemente como una línea con descripción (display_type).

También si por ejemplo hay 2 líneas con 2 productos con impuestos distintos (supongamos 21% y 15%) entonces se crean 2 líneas de anticipo una con el 21% y la otra con el 15%.