### PR TITLE
[IMP]sale_timesheet_extra_hours: keep same cost in account.analytic.lines

### DIFF
--- a/sale_timesheet_extra_hours/__manifest__.py
+++ b/sale_timesheet_extra_hours/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "Sales Timesheet Extra Hours",
     "summary": "",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",
     "author": "ADHOC SA",

--- a/sale_timesheet_extra_hours/models/account_analytic_line.py
+++ b/sale_timesheet_extra_hours/models/account_analytic_line.py
@@ -13,24 +13,30 @@ class AccountAnalyticLine(models.Model):
         default="day",
     )
 
+    cost = fields.Float()
+
     def _hourly_cost(self):
+        if self.cost != 0.0:
+            return self.cost
         if self.project_id.pricing_type == "fixed_rate":
             self.ensure_one()
             if self.extra_hour:
                 if self.extra_hour_type == "day":
-                    return self.employee_id.day_extra_hour_cost
+                    self.cost = self.employee_id.day_extra_hour_cost
                 else:
-                    return self.employee_id.night_extra_hour_cost
+                    self.cost = self.employee_id.night_extra_hour_cost
             else:
-                return self.employee_id.hourly_cost or 0.0
+                self.cost = self.employee_id.hourly_cost or 0.0
+            return self.cost
         if self.project_id.pricing_type == "employee_rate":
             mapping_entry = self._get_employee_mapping_entry()
             if mapping_entry:
                 if self.extra_hour:
                     if self.extra_hour_type == "day":
-                        return mapping_entry.cost_day_extra_hour
+                        self.cost = mapping_entry.cost_day_extra_hour
                     else:
-                        return mapping_entry.cost_night_extra_hour
+                        self.cost = mapping_entry.cost_night_extra_hour
                 else:
-                    return mapping_entry.cost or 0.0
+                    self.cost = mapping_entry.cost or 0.0
+            return self.cost
         return super()._hourly_cost()

--- a/sale_timesheet_extra_hours/views/account_analytic_line_views.xml
+++ b/sale_timesheet_extra_hours/views/account_analytic_line_views.xml
@@ -20,6 +20,8 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='unit_amount']" position="before">
                 <field string="Extra Cost" readonly="1" name="extra_hour" optional="hide"  widget="boolean_toggle"/>
+                <field string="Extra Hour Type" readonly="1" name="extra_hour_type" invisible="not extra_hour" optional="hide"/>
+                <field string="Cost Per Hour" readonly="1" name="cost" optional="hide"/>
             </xpath>
         </field>
     </record>
@@ -31,6 +33,8 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='amount']" position="before">
                 <field string="Extra Cost" readonly="1" name="extra_hour" optional="hide"  widget="boolean_toggle"/>
+                <field string="Extra Hour Type" readonly="1" name="extra_hour_type" invisible="not extra_hour" optional="hide"/>
+                <field string="Cost Per Hour" readonly="1" name="cost" optional="hide"/>
             </xpath>
         </field>
     </record>
@@ -41,8 +45,20 @@
         <field name="inherit_id" ref="analytic.view_account_analytic_line_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='product_uom_id']" position="after">
-                <field string="Extra Cost" readonly="1" name="extra_hour" widget="boolean_toggle"/>
+                <field string="Extra Cost" name="extra_hour" widget="boolean_toggle"/>
+                <field string="Extra Hour Type" name="extra_hour_type" invisible="not extra_hour"/>
             </xpath>
         </field>
     </record>
+    <record id="hr_timesheet_line_form_ux" model="ir.ui.view">
+            <field name="name">account.analytic.line.form.inherit</field>
+            <field name="model">account.analytic.line</field>
+            <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='unit_amount']" position="after">
+                    <field name="extra_hour" widget="boolean_toggle"/>
+                    <field name="extra_hour_type" invisible="not extra_hour"/>
+                </xpath>
+            </field>
+        </record>
 </odoo>


### PR DESCRIPTION
keeps the same cost for past imputed lines when changing the fare on the project