### PR TITLE
[FIX] sale_ux: Prevent tax change in sale order line when in downpayment invoice use company changes wizard

### DIFF
--- a/sale_ux/models/account_move.py
+++ b/sale_ux/models/account_move.py
@@ -38,6 +38,7 @@ class AccountMove(models.Model):
             lambda l: l.is_downpayment and not l.display_type
         )
         for downpayment_line in downpayment_lines:
+            # When change currency in downpayment
             if self.currency_id != downpayment_line.currency_id:
                 downpayment_line.price_unit = self.currency_id._convert(
                     downpayment_line.price_unit, 
@@ -45,4 +46,7 @@ class AccountMove(models.Model):
                     self.company_id, 
                     self.invoice_date or fields.Date.today()
                 )
+            # When change company in downpayment
+            if downpayment_line.company_id != self.company_id:
+                downpayment_line.with_company(downpayment_line.company_id.id)._compute_tax_ids()
         return res


### PR DESCRIPTION
Previously, when the company of an downpayment invoice was changed,
the tax on the related sale order line was also updated incorrectly. 

This commit ensures that the tax remains unchanged regardless of invoice company modifications.