### PR TITLE
[FIX] sale_order_type_ux: When creating downpayment product unset company_id to avoid multi-company issues

### DIFF
--- a/sale_order_type_ux/__manifest__.py
+++ b/sale_order_type_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Sale Order Type Ux',
-    'version': "17.0.1.2.0",
+    'version': "17.0.1.3.0",
     'category': 'Accounting',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/sale_order_type_ux/models/sale_order_line.py
+++ b/sale_order_type_ux/models/sale_order_line.py
@@ -2,11 +2,17 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import models, api
+from odoo import models, api, fields
 
 
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
+
+    # Quitamos el check_company ya que no permitira 
+    # realizar un cambio de compañia entre la venta y su factura de anticipo
+    tax_id = fields.Many2many(
+        check_company=False
+    )
 
     def _prepare_invoice_line(self, **optional_values):
         """

--- a/sale_order_type_ux/wizards/sale_advance_payment_inv.py
+++ b/sale_order_type_ux/wizards/sale_advance_payment_inv.py
@@ -27,3 +27,9 @@ class SaleAdvancePaymentInv(models.TransientModel):
             res['invoice_line_ids'][0][2]['tax_ids'] = [(6, 0, tax_ids)]
 
         return res
+
+    def _prepare_down_payment_product_values(self):
+        res = super()._prepare_down_payment_product_values()
+        if res['company_id']:
+            res['company_id'] = False
+        return res


### PR DESCRIPTION
Unset the 'company_id' on the product created for down payments 
by overriding '_prepare_down_payment_product_values'.

This avoids issues when creating invoices in a different company 
than the one that originally created the down payment product, especially in multi-company environments.