### PR TITLE
[FIX] sale_ux: Fix in method calls. We need to call _compute_tax_id instead of _compute_tax_ids

### DIFF
--- a/sale_ux/models/account_move.py
+++ b/sale_ux/models/account_move.py
@@ -48,5 +48,5 @@ class AccountMove(models.Model):
                 )
             # When change company in downpayment
             if downpayment_line.company_id != self.company_id:
-                downpayment_line.with_company(downpayment_line.company_id.id)._compute_tax_ids()
+                downpayment_line.with_company(downpayment_line.company_id.id)._compute_tax_id()
         return res


### PR DESCRIPTION

The method `_compute_tax_ids` was incorrectly used in the context where the correct method is `_compute_tax_id`. 

This fix ensures that the correct tax computation method is invoked, 
leading to accurate tax calculations.