### PR TITLE
[FIX] sale_order_type_ux: Fix downpayment creation with multicompany sale order type

### DIFF
--- a/sale_order_type_ux/wizards/sale_advance_payment_inv.py
+++ b/sale_order_type_ux/wizards/sale_advance_payment_inv.py
@@ -20,19 +20,23 @@ class SaleAdvancePaymentInv(models.TransientModel):
         if company.id != order.company_id.id:
             for line_downpayment in so_line.filtered("is_downpayment"):
                 tax = line_downpayment.tax_id
-                if order.fiscal_position_id and tax:
-                    tax_ids = order.fiscal_position_id.map_tax(tax).ids
+                # Buscamos el correcto tax para la compañia sobre la cual estoy facturando, siendo
+                # esta distinta a la de la sale order line
+                correct_company_tax = self.env["account.tax"].search(
+                    [
+                        ("company_id", "=", company.id),
+                        ("type_tax_use", "=", tax.type_tax_use),
+                        ("company_price_include", "=", tax.company_price_include),
+                        ("amount", "=", tax.amount),
+                    ]
+                )
+                if order.fiscal_position_id and correct_company_tax:
+                    tax_ids = order.fiscal_position_id.map_tax(correct_company_tax).ids
                 else:
-                    tax_ids = tax.ids
+                    tax_ids = correct_company_tax.ids or False
 
                 for line in res["invoice_line_ids"]:
                     if line[2]["is_downpayment"] and line[2]["sale_line_ids"][0][1] == line_downpayment.id:
                         line[2]["tax_ids"] = [(6, 0, tax_ids)]
 
-        return res
-
-    def _prepare_down_payment_product_values(self):
-        res = super()._prepare_down_payment_product_values()
-        if res["company_id"]:
-            res["company_id"] = False
         return res

--- a/sale_ux/models/account_move.py
+++ b/sale_ux/models/account_move.py
@@ -38,5 +38,17 @@ class AccountMove(models.Model):
                 )
             # When change company in downpayment
             if downpayment_line.company_id != self.company_id:
-                downpayment_line.with_company(downpayment_line.company_id.id)._compute_tax_id()
+                tax = downpayment_line.tax_id
+                # Buscamos el correcto tax para la compañia sobre la cual estoy vendiendo, siendo
+                # esta distinta a la de la factura de anticipo
+                correct_company_tax = self.env["account.tax"].search(
+                    [
+                        ("company_id", "=", downpayment_line.company_id.id),
+                        ("type_tax_use", "=", tax.type_tax_use),
+                        ("company_price_include", "=", tax.company_price_include),
+                        ("amount", "=", tax.amount),
+                    ]
+                )
+                tax = correct_company_tax or False
+                downpayment_line.tax_id = tax
         return res


### PR DESCRIPTION

When creating a downpayment invoice from a sale order using a sale order type with a journal from a different company, the taxes were not correctly adapted to the journal's company. This caused tax inconsistencies and incorrect tax mapping.

This fix ensures that:
- The invoice is prepared in the correct company context based on the journal set on the sale order type.
- Downpayment lines use taxes correctly mapped to the company issuing the invoice.
- If a fiscal position is defined, the taxes are mapped accordingly.

This avoids tax company mismatch errors in multicompany environments.