### PR TITLE
[FIX] sale_order_type_ux: Fix tax mapping for down payments without product in regular invoice generation

### DIFF
--- a/sale_order_type_ux/models/sale_order_line.py
+++ b/sale_order_type_ux/models/sale_order_line.py
@@ -30,7 +30,21 @@ class SaleOrderLine(models.Model):
                 .with_company(company.id)
                 ._get_fiscal_position(self.order_id.partner_id, self.order_id.partner_shipping_id)
             )
-            taxes = self.product_id.taxes_id.filtered(lambda r: company == r.company_id)
-            taxes = fpos.map_tax(taxes) if fpos else taxes
+            correct_company_tax = self.env["account.tax"].search(
+                [
+                    ("company_id", "=", company.id),
+                    ("type_tax_use", "=", self.tax_id.type_tax_use),
+                    ("company_price_include", "=", self.tax_id.company_price_include),
+                    ("amount", "=", self.tax_id.amount),
+                    ("amount_type", "=", self.amount_type),
+                ]
+            )
+            taxes = (
+                self.product_id.taxes_id.filtered(lambda r: company == r.company_id)
+                if self.product_id
+                else correct_company_tax
+            )
+            if fpos and taxes:
+                taxes = fpos.map_tax(taxes) if fpos else taxes
             res["tax_ids"] = [(6, 0, taxes.ids)]
         return res


### PR DESCRIPTION
When generating invoices that deduct previously invoiced down payments, downpayment lines not have a product set. The original logic relied on the product's taxes, which caused these lines to miss tax mapping.

This commit now includes a fallback mechanism to search for matching taxes manually (based on type, inclusion in price, and amount) when no product taxes are available.

This ensures fiscal position mapping works properly for all invoice lines, including down payments.