### PR TITLE
[FIX] sale_order_type_ux: fix invoice line preparation accessing tax amount_type

### DIFF
--- a/sale_order_type_ux/models/sale_order_line.py
+++ b/sale_order_type_ux/models/sale_order_line.py
@@ -36,7 +36,7 @@ class SaleOrderLine(models.Model):
                     ("type_tax_use", "=", self.tax_id.type_tax_use),
                     ("company_price_include", "=", self.tax_id.company_price_include),
                     ("amount", "=", self.tax_id.amount),
-                    ("amount_type", "=", self.amount_type),
+                    ("amount_type", "=", self.tax_id.amount_type),
                 ]
             )
             taxes = (


### PR DESCRIPTION

The _prepare_invoice_line method incorrectly accessed `amount_type` directly from sale.order.line, which does not have such a field. This caused an AttributeError.

The access has been corrected to retrieve `amount_type` from the related `tax_id`, which belongs to the account.tax model.

Additionally, this ensures compatibility when switching company context during invoice generation based on the sales order type journal's company.