### PR TITLE
[FIX] sale_ux: Refine sale order cancellation check based on invoice and debit note payment status

### DIFF
--- a/sale_ux/models/sale_order.py
+++ b/sale_ux/models/sale_order.py
@@ -90,7 +90,14 @@ class SaleOrder(models.Model):
     def action_cancel(self):
         invoice_lines = self.sudo().env["account.move.line"].search([('sale_line_ids', 'in', self.order_line.ids)])
         moves = invoice_lines.mapped('move_id').filtered(
-            lambda x: x.move_type in ('out_invoice', 'out_refund') and x.state not in ['cancel', 'draft']
+            lambda x: x.move_type in ('out_invoice', 'out_debit') 
+            and x.state not in ['cancel', 'draft']
+            and not (
+                # When out_invoice should not be reversed
+                (x.move_type == 'out_invoice' and x.payment_state == 'reversed') or
+                # When out_debit should not be paid
+                (x.move_type == 'out_debit' and x.payment_state == 'paid')
+            )
         )
         if moves:
             raise UserError(_(


### PR DESCRIPTION
Improves the condition that prevents a sale order from being cancelled if related invoices or debit notes are still active.

- For customer invoices (`out_invoice`), skip those that are already reversed.
- For customer debit notes (`out_debit`), skip those that are fully paid.
- Keeps existing exclusions for moves in draft or cancelled state.

This prevents false positives in the cancellation restriction and ensures only truly active financial documents block the operation.