### PR TITLE
[FIX] sale_ux: Refine sale order cancellation check based on invoice and debit note payment status

### DIFF
--- a/sale_ux/README.rst
+++ b/sale_ux/README.rst
@@ -25,6 +25,8 @@ Several Improvements to sales:
 #. Allow cancel sales orders in locked state and unlock it after cancelling
 #. Fix in button "Create invoice" in sale orders, to create a refund invoice if the sale order amount it's zero and the line's quantities are negative (because of a return).
 #. Block cancellation of a sale order if there is a related invoice in a state different from "draft" or "cancel".
+   Customer invoices (out_invoice) are excluded if they have been reversed.
+   Customer debit notes (out_debit) are excluded if they are fully paid.
 #. Customer Preview" button in sale orders, opens the online quotation in a new tab.
 #. We rename the field price_subtotal and price_total to "Subtotal" and "Total" respectively in sale.order.form
 #. Add option in Sales settings to update prices automatically.

--- a/sale_ux/models/sale_order.py
+++ b/sale_ux/models/sale_order.py
@@ -80,7 +80,16 @@ class SaleOrder(models.Model):
         moves = invoice_lines.mapped("move_id").filtered(
             lambda x: x.move_type in ("out_invoice", "out_refund") and x.state not in ["cancel", "draft"]
         )
-        if moves:
+        # Check that all invoices are reversed and belong to this sale order
+        invoices = moves.filtered(lambda m: m.move_type == "out_invoice")
+        valid_invoices = all(inv.payment_state == "reversed" and inv.invoice_origin == self.name for inv in invoices)
+        # Check that all refunds are paid and belong to this sale order
+        if valid_invoices:
+            refunds = moves.filtered(lambda m: m.move_type == "out_refund")
+            valid_refunds = all(ref.payment_state == "paid" and ref.invoice_origin == self.name for ref in refunds)
+            valid_invoices = valid_refunds if refunds else False
+
+        if moves and not (valid_invoices):
             raise UserError(_("Unable to cancel this sale order. You must first " "cancel related bills and pickings."))
         if any(order.locked for order in self):
             # No encontre otra forma de evitar el raise usererror que impide que ordenes se cancelen si el pedido está bloqueado


### PR DESCRIPTION


Improves the condition that prevents a sale order from being cancelled if related invoices or debit notes are still active.

- For customer invoices (`out_invoice`), skip those that are already reversed.
- For customer debit notes (`out_debit`), skip those that are fully paid.
- Keeps existing exclusions for moves in draft or cancelled state.

This prevents false positives in the cancellation restriction and ensures only truly active financial documents block the operation.