### PR TITLE
[FIX] sale_three_discounts: [200~Rename custom onchange method to av…

### DIFF
--- a/sale_three_discounts/models/sale_order_line.py
+++ b/sale_three_discounts/models/sale_order_line.py
@@ -65,7 +65,7 @@ class SaleOrderLine(models.Model):
                 line.discount3 = 0.0
 
     @api.onchange("product_id")
-    def _onchange_product(self):
+    def _onchange_products(self):
         self.with_context(onchange_product=True)._compute_discounts()
 
     def _prepare_invoice_line(self, **optional_values):


### PR DESCRIPTION
…oid conflict with native Odoo implementation

-------
Odoo added a method named _onchange_product in the sale_pdf_quote_builder module, which caused a conflict with our custom implementation. Renamed the method to _onchange_products to avoid overriding the native behavior.
