### PR TITLE
[ADD] sale_project_ux: Add support for analytic account without company setting

### DIFF
--- a/sale_project_ux/README.rst
+++ b/sale_project_ux/README.rst
@@ -1,0 +1,70 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+===============
+Sale Project UX
+===============
+
+Added functionality to allow the creation of projects without a company based on the sale_ux.analytic_account_without_company setting. When enabled, the system will create projects without assigning a company.
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Only need to install the module
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Nothing to configure
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Only use it
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: http://runbot.adhoc.com.ar/
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/ingadhoc/sale/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* |company| |icon|
+
+Contributors
+------------
+
+Maintainer
+----------
+
+|company_logo|
+
+This module is maintained by the |company|.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/sale_project_ux/__init__.py
+++ b/sale_project_ux/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import models

--- a/sale_project_ux/__manifest__.py
+++ b/sale_project_ux/__manifest__.py
@@ -1,0 +1,39 @@
+##############################################################################
+#
+#    Copyright (C) 2015  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Sale Project UX",
+    "version": "18.0.1.0.0",
+    "category": "Sales",
+    "sequence": 14,
+    "summary": "",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "images": [],
+    "depends": [
+        "sale_project",
+        "sale_ux",
+    ],
+    "data": [],
+    "demo": [],
+    "installable": True,
+    "auto_install": True,
+    "application": False,
+}

--- a/sale_project_ux/models/__init__.py
+++ b/sale_project_ux/models/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import sale_order_line

--- a/sale_project_ux/models/sale_order_line.py
+++ b/sale_project_ux/models/sale_order_line.py
@@ -1,0 +1,24 @@
+from odoo import models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _timesheet_create_project_prepare_values(self):
+        """Generate project values"""
+        if (
+            self.env["ir.config_parameter"].sudo().get_param("sale_ux.analytic_account_without_company", "False")
+            == "True"
+        ):
+            return {
+                "name": "%s - %s" % (self.order_id.client_order_ref, self.order_id.name)
+                if self.order_id.client_order_ref
+                else self.order_id.name,
+                "partner_id": self.order_id.partner_id.id,
+                "sale_line_id": self.id,
+                "active": True,
+                "company_id": False,
+                "allow_billable": True,
+                "user_id": self.product_id.project_template_id.user_id.id,
+            }
+        return super(SaleOrderLine, self)._timesheet_create_project_prepare_values()


### PR DESCRIPTION
Added functionality to allow the creation of projects without a company based on the sale_ux.analytic_account_without_company setting. When enabled, the system will create projects without assigning a company.