### PR TITLE
[FIX] sale_order_type_ux: Fix tax mapping for downpayment when invoicng from another company

### DIFF
--- a/sale_order_type_ux/wizards/sale_advance_payment_inv.py
+++ b/sale_order_type_ux/wizards/sale_advance_payment_inv.py
@@ -19,21 +19,23 @@ class SaleAdvancePaymentInv(models.TransientModel):
         res = super()._prepare_invoice_values(order, so_line, accounts)
         if company.id != order.company_id.id:
             for line_downpayment in so_line.filtered("is_downpayment"):
-                tax = line_downpayment.tax_id
+                taxes = line_downpayment.tax_id
                 # Buscamos el correcto tax para la compañia sobre la cual estoy facturando, siendo
                 # esta distinta a la de la sale order line
-                correct_company_tax = self.env["account.tax"].search(
+                correct_company_taxes = self.env["account.tax"].search(
                     [
                         ("company_id", "=", company.id),
-                        ("type_tax_use", "=", tax.type_tax_use),
-                        ("company_price_include", "=", tax.company_price_include),
-                        ("amount", "=", tax.amount),
+                        ("type_tax_use", "in", taxes.mapped("type_tax_use")),
+                        ("company_price_include", "in", taxes.mapped("company_price_include")),
+                        ("amount", "in", taxes.mapped("amount")),
+                        ("amount_type", "in", taxes.mapped("amount_type")),
                     ]
                 )
-                if order.fiscal_position_id and correct_company_tax:
-                    tax_ids = order.fiscal_position_id.map_tax(correct_company_tax).ids
+
+                if order.fiscal_position_id and correct_company_taxes:
+                    tax_ids = order.fiscal_position_id.map_tax(correct_company_taxes).ids
                 else:
-                    tax_ids = correct_company_tax.ids or False
+                    tax_ids = correct_company_taxes.ids
 
                 for line in res["invoice_line_ids"]:
                     if line[2]["is_downpayment"] and line[2]["sale_line_ids"][0][1] == line_downpayment.id:

--- a/sale_ux/models/account_move.py
+++ b/sale_ux/models/account_move.py
@@ -38,15 +38,16 @@ class AccountMove(models.Model):
                 )
             # When change company in downpayment
             if downpayment_line.company_id != self.company_id:
-                tax = downpayment_line.tax_id
+                taxes = downpayment_line.tax_id
                 # Buscamos el correcto tax para la compañia sobre la cual estoy vendiendo, siendo
                 # esta distinta a la de la factura de anticipo
                 correct_company_tax = self.env["account.tax"].search(
                     [
                         ("company_id", "=", downpayment_line.company_id.id),
-                        ("type_tax_use", "=", tax.type_tax_use),
-                        ("company_price_include", "=", tax.company_price_include),
-                        ("amount", "=", tax.amount),
+                        ("type_tax_use", "in", taxes.mapped("type_tax_use")),
+                        ("company_price_include", "in", taxes.mapped("company_price_include")),
+                        ("amount", "in", taxes.mapped("amount")),
+                        ("amount_type", "in", taxes.mapped("amount_type")),
                     ]
                 )
                 tax = correct_company_tax or False


### PR DESCRIPTION


This fix addresses the issue where downpayment lines with multiple taxes are not correctly mapped when the sale order belongs to company A but the invoice is issued from company B due to the sale order type.

The selected taxes are now filtered by company B and matched by type, amount, and price_include, ensuring compatibility with the fiscal position mapping. This ensures proper tax mapping when invoicing across companies.