### PR TITLE
[FIX] sale_order_type_ux: fix discount lines when creating invoices

### DIFF
--- a/sale_order_type_ux/models/sale_order_line.py
+++ b/sale_order_type_ux/models/sale_order_line.py
@@ -2,7 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import models, api, fields
+from odoo import _, models, api, fields
 
 
 class SaleOrderLine(models.Model):
@@ -25,14 +25,33 @@ class SaleOrderLine(models.Model):
         res = super()._prepare_invoice_line(**optional_values)
 
         if company != self.company_id:
-            # Because we not have the access to the invoice, we obtain the fiscal position who
-            # has the invoice really
-            fpos = self.env['account.fiscal.position'].with_company(
-                company.id)._get_fiscal_position(
-                self.order_id.partner_id,
-                self.order_id.partner_shipping_id)
-            taxes = self.product_id.taxes_id.filtered(
-                lambda r: company == r.company_id)
-            taxes = fpos.map_tax(taxes) if fpos else taxes
+            if self.product_id and self.product_id.name == _('Discount'):
+                taxes = self._get_change_company_line_discount_tax(company=company)
+            else:
+                # Because we not have the access to the invoice, we obtain the fiscal position who
+                # has the invoice really
+                fpos = self.env['account.fiscal.position'].with_company(
+                    company.id)._get_fiscal_position(
+                    self.order_id.partner_id,
+                    self.order_id.partner_shipping_id)
+                taxes = self.product_id.taxes_id.filtered(
+                    lambda r: company == r.company_id)
+                taxes = fpos.map_tax(taxes) if fpos else taxes
+
             res['tax_ids'] = [(6, 0, taxes.ids)]
         return res
+
+    def _get_change_company_line_discount_tax(self, company=None):
+        tax_ids = self.env['account.tax'].browse(self.tax_id.ids)
+        taxes = self.env['account.tax']
+        for tax in tax_ids:
+            new_tax = self.env['account.tax'].search([
+                ('type_tax_use', '=', tax.type_tax_use),
+                ('amount', '=', tax.amount),
+                ('active', '=', True),
+                ('company_id', '=', company.id),
+            ], limit=1)
+            if new_tax:
+                taxes += new_tax
+
+        return taxes

--- a/sale_order_type_ux/wizards/sale_advance_payment_inv.py
+++ b/sale_order_type_ux/wizards/sale_advance_payment_inv.py
@@ -2,7 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import models
+from odoo import _, models
 
 
 class SaleAdvancePaymentInv(models.TransientModel):
@@ -33,3 +33,14 @@ class SaleAdvancePaymentInv(models.TransientModel):
         if res['company_id']:
             res['company_id'] = False
         return res
+
+    def _create_invoices(self, sale_orders):
+        # if discount product has a company associated, we need to remove it before changing the company in invoice
+        if self.mapped('sale_order_ids.type_id.journal_id.company_id') != self.mapped('sale_order_ids.company_id'):
+            discount_lines = self.mapped('sale_order_ids.order_line').filtered(
+                lambda x: x.product_id and x.product_id.name == _('Discount')
+            )
+            if discount_lines and discount_lines.product_id.company_id:
+                discount_lines[0].product_id.write({'company_id': False})
+
+        return super(SaleAdvancePaymentInv, self)._create_invoices(sale_orders=sale_orders)


### PR DESCRIPTION
1. Added an import for Odoo's translation function _ from odoo.
2. Added a new method _create_invoices that overrides the parent class method. The changes include:
-  A check for company mismatch between the sale order type's journal and the sale orders
-  If there's a mismatch and there are discount lines (where product name is 'Discount'), the code removes the company from the discount product
-  Finally, it calls the parent class's implementation of _create_invoices