### PR TITLE
[FIX] sale_ux: Ensure correct account on downpayment lines

### DIFF
--- a/sale_ux/models/sale_order_line.py
+++ b/sale_ux/models/sale_order_line.py
@@ -51,3 +51,27 @@ class SaleOrderLine(models.Model):
 
     def _get_protected_fields(self):
         return super()._get_protected_fields() + ["discount"]
+
+    def _prepare_invoice_line(self, **optional_values):
+        res = super()._prepare_invoice_line(**optional_values)
+        # Fix multicompañía: si se cambia la compañía de una factura de anticipo con el wizard de change company,
+        # luego al facturar el resto se puede usar una cuenta contable de la compañía incorrecta.
+
+        downpayment_lines = self.invoice_lines.filtered("is_downpayment")
+        account_id = res.get("account_id") and self.env["account.account"].browse(res["account_id"]) or None
+
+        if (
+            self.is_downpayment
+            and downpayment_lines
+            and account_id
+            and self.company_id.id not in account_id.company_ids.ids
+        ):
+            invoiceable_products = self.order_id._get_invoiceable_lines().mapped("product_id")
+            product_accounts = invoiceable_products.product_tmpl_id.get_product_accounts(
+                fiscal_pos=self.order_id.fiscal_position_id
+            )
+            new_account = product_accounts.get("downpayment") or product_accounts.get("income")
+            if new_account:
+                res["account_id"] = new_account.id
+
+        return res


### PR DESCRIPTION
When creating a downpayment invoice for a sale order and then changing its company using the "Change Company" wizard and do not have a specific downpayment account in the product category, the account used in future invoices (to deduct the downpayment) could belong to the wrong company.

This happened when the product's category lacked a specific downpayment account and the default income account was not shared across companies.

This fix ensures that the account assigned to the downpayment deduction line in the final invoice belongs to the invoice's company. It fetches the proper account from the product's template, taking fiscal position into account.