### PR TITLE
[ADD] sale_payment_options: add new module

### DIFF
--- a/sale_payment_options/README.rst
+++ b/sale_payment_options/README.rst
@@ -1,0 +1,78 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+=====================
+Sale Payment Options
+=====================
+
+Allows defining and displaying multiple payment options on quotations and sales orders.
+
+- Configure several payment options per sales order.
+- Edit payment options only through a wizard.
+- Reusable payment option templates.
+- Visual display of payment options in the order.
+- Automatic recalculation if the order total changes.
+- Each payment option can have multiple installment plans.
+- Payment options are shown in the sales order PDF, with tables, subtotals, and totals.
+- Handles missing or malformed data gracefully in reports.
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Just install.
+
+Configuration
+=============
+
+No additional configuration is required.
+
+Usage
+=====
+
+#. Open a sales order and go to the "Payment Options" tab.
+#. Click "Edit Payment Options" to use the wizard.
+#. Select a template or add payment lines manually.
+#. Save to apply the payment options to the order.
+#. The summary appears in the order (read-only).
+#. When printing, payment options are shown as tables with installment details and totals.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/ingadhoc/sale/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* |company| |icon|
+
+Contributors
+------------
+
+* ADHOC SA <https://www.adhoc.com.ar>
+
+Maintainer
+----------
+
+|company_logo|
+
+This module is maintained by the |company|.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/sale_payment_options/__init__.py
+++ b/sale_payment_options/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/sale_payment_options/__manifest__.py
+++ b/sale_payment_options/__manifest__.py
@@ -1,0 +1,45 @@
+##############################################################################
+#
+#    Copyright (C) 2015  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Sale Payment Options",
+    "summary": "Manage and display payment options on quotations and sales orders.",
+    "version": "18.0.1.0.0",
+    "category": "Sales",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "depends": ["sale", "card_installment"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/sale_order_views.xml",
+        "views/sale_payment_option_template_views.xml",
+        "wizard/sale_payment_option_wizard_views.xml",
+        "report/sale_order_payment_options_report.xml",
+        "report/ir_actions_report.xml",
+    ],
+    "installable": True,
+    "application": False,
+    "auto_install": False,
+    "assets": {
+        "web.assets_backend": [
+            "sale_payment_options/static/src/css/sale_payment_options.css",
+        ],
+    },
+}

--- a/sale_payment_options/i18n/es.po
+++ b/sale_payment_options/i18n/es.po
@@ -1,0 +1,299 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* sale_payment_options
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-30 23:42+0000\n"
+"PO-Revision-Date: 2025-06-30 23:42+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_payment_options
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.report_saleorder_payment_options_document
+msgid "% OV"
+msgstr "% OV"
+
+#. module: sale_payment_options
+#: model:ir.actions.report,print_report_name:sale_payment_options.action_report_saleorder_payment_options
+msgid "(object.state in ('draft', 'sent') and 'Quotation - %s' % (object.name)) or 'Order - %s' % (object.name)"
+msgstr "(object.state in ('draft', 'sent') and 'Presupuesto - %s' % (object.name)) or 'Pedido - %s' % (object.name)"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_template__active
+msgid "Active"
+msgstr "Activo"
+
+#. module: sale_payment_options
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.view_order_form_inherit_payment_options
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.view_sale_payment_option_template_form
+msgid "Add Payment Option"
+msgstr "Agregar opción de pago"
+
+#. module: sale_payment_options
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.view_sale_payment_option_wizard_form
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: sale_payment_options
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.view_sale_payment_option_wizard_form
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: sale_payment_options
+#: model_terms:ir.actions.act_window,help:sale_payment_options.action_sale_payment_option_template
+msgid "Create payment option templates to reuse payment configurations in sales orders."
+msgstr "Cree plantillas de opciones de pago para reutilizar configuraciones de pago en los pedidos de venta."
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option__create_uid
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_template__create_uid
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard__create_uid
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard_line__create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option__create_date
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_template__create_date
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard__create_date
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard_line__create_date
+msgid "Created on"
+msgstr "Creado el"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard__currency_id
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard_line__currency_id
+msgid "Currency"
+msgstr "Moneda"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option__options_json_rendered
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.view_order_form_inherit_payment_options
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.view_sale_payment_option_template_form
+msgid "Details"
+msgstr "Detalles"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option__display_name
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_template__display_name
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard__display_name
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard_line__display_name
+msgid "Display Name"
+msgstr "Nombre"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard_line__installment_qty
+msgid "Divisor"
+msgstr "Divisor"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,help:sale_payment_options.field_sale_payment_option_wizard_line__surcharge_coefficient
+msgid "Factor a aplicar sobre el monto total para calcular el cargo financiero. Por ejemplo el formato para el recargo de un 6% se aplica con el valor 1.06."
+msgstr "Factor a aplicar sobre el monto total para calcular el cargo financiero. Por ejemplo, el formato para el recargo de un 6% se aplica con el valor 1.06."
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option__id
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_template__id
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard__id
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard_line__id
+msgid "ID"
+msgstr "ID"
+
+#. module: sale_payment_options
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.view_sale_payment_option_wizard_form
+msgid "Installment"
+msgstr "Cuota"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard_line__card_installment_id
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.report_saleorder_payment_options_document
+msgid "Installment Plan"
+msgstr "Plan de cuotas"
+
+#. module: sale_payment_options
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.report_saleorder_payment_options_document
+msgid "Installment quantity"
+msgstr "Cantidad de cuotas"
+
+#. module: sale_payment_options
+#. odoo-python
+#: code:addons/odoo/odoo/addons/sale_payment_options/models/sale_order.py:0
+#: code:addons/sale_payment_options/models/sale_order.py:0
+msgid "Invalid configuration"
+msgstr "Configuración inválida"
+
+#. module: sale_payment_options
+#. odoo-python
+#: code:addons/sale_payment_options/models/sale_order.py:0
+msgid "Invalid Template Configuration"
+msgstr "Configuración de plantilla inválida"
+
+#. module: sale_payment_options
+#. odoo-python
+#: code:addons/sale_payment_options/models/sale_order.py:0
+msgid "The following options don't sum to 100%%:\n%s"
+msgstr "Las siguientes opciones no suman 100%%:\n%s"
+
+#. module: sale_payment_options
+#. odoo-python
+#: code:addons/sale_payment_options/models/sale_order.py:0
+msgid "The following payment options have invalid percentage totals (must be exactly 100%%):\n%s"
+msgstr "Las siguientes opciones de pago tienen totales de porcentaje inválidos (deben ser exactamente 100%%):\n%s"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option__write_uid
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_template__write_uid
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard__write_uid
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard_line__write_uid
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option__write_date
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_template__write_date
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard__write_date
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard_line__write_date
+msgid "Last Updated on"
+msgstr "Última actualización el"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_template__name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,help:sale_payment_options.field_sale_payment_option_wizard_line__installment_qty
+msgid "Número por el cual se dividirá el total de cuotas que pagará el usuario final"
+msgstr "Número por el cual se dividirá el total de cuotas que pagará el usuario final"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option__options_json
+msgid "Options Json"
+msgstr "Opciones Json"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard__total
+msgid "Order Total"
+msgstr "Total del pedido"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard__line_ids
+msgid "Payment Lines"
+msgstr "Líneas de pago"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_order__payment_option_template_id
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option__payment_option_template_id
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard__payment_option_template_id
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.view_order_form_inherit_payment_options
+msgid "Payment Option Template"
+msgstr "Plantilla de opción de pago"
+
+#. module: sale_payment_options
+#: model:ir.actions.act_window,name:sale_payment_options.action_sale_payment_option_template
+#: model:ir.ui.menu,name:sale_payment_options.menu_sale_payment_option_template
+msgid "Payment Option Templates"
+msgstr "Plantillas de opciones de pago"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_order__payment_option_ids
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_template__payment_option_ids
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.report_saleorder_payment_options_document
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.view_order_form_inherit_payment_options
+msgid "Payment Options"
+msgstr "Opciones de pago"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard_line__percentage
+msgid "Percentage"
+msgstr "Porcentaje"
+
+#. module: sale_payment_options
+#: model:ir.actions.report,name:sale_payment_options.action_report_saleorder_payment_options
+msgid "Quotation / Order (Payment Options)"
+msgstr "Presupuesto / Pedido (Opciones de pago)"
+
+#. module: sale_payment_options
+#: model:ir.model,name:sale_payment_options.model_sale_payment_option
+msgid "Sale payment option"
+msgstr "Opción de pago de venta"
+
+#. module: sale_payment_options
+#: model:ir.model,name:sale_payment_options.model_sale_payment_option_template
+msgid "Sale payment option template"
+msgstr "Plantilla de opción de pago de venta"
+
+#. module: sale_payment_options
+#: model:ir.model,name:sale_payment_options.model_sale_payment_option_wizard
+msgid "Sale payment option wizard"
+msgstr "Asistente de opción de pago de venta"
+
+#. module: sale_payment_options
+#: model:ir.model,name:sale_payment_options.model_sale_payment_option_wizard_line
+msgid "Sale payment option wizard line"
+msgstr "Línea de asistente de opción de pago de venta"
+
+#. module: sale_payment_options
+#: model:ir.model,name:sale_payment_options.model_sale_order
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option__sale_order_id
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard__sale_order_id
+msgid "Sales Order"
+msgstr "Orden de venta"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option__sequence
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard_line__subtotal
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.report_saleorder_payment_options_document
+msgid "Subtotal"
+msgstr "Subtotal"
+
+#. module: sale_payment_options
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.report_saleorder_payment_options_document
+msgid "Surcharge"
+msgstr "Recargo"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard_line__surcharge_coefficient
+msgid "Surcharge Coefficient"
+msgstr "Coeficiente de recargo"
+
+#. module: sale_payment_options
+#. odoo-python
+#: code:addons/odoo/odoo/addons/sale_payment_options/wizard/sale_payment_option_wizard.py:0
+#: code:addons/sale_payment_options/wizard/sale_payment_option_wizard.py:0
+msgid "The sum of the percentages must be exactly 100."
+msgstr "La suma de los porcentajes debe ser exactamente 100."
+
+#. module: sale_payment_options
+#. odoo-python
+#: code:addons/odoo/odoo/addons/sale_payment_options/models/sale_order.py:0
+#: code:addons/sale_payment_options/models/sale_order.py:0
+msgid "The sum of the percentages of each template option must be exactly 100%."
+msgstr "La suma de los porcentajes de cada opción de plantilla debe ser exactamente 100%."
+
+#. module: sale_payment_options
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.report_saleorder_payment_options_document
+msgid "Total"
+msgstr "Total"
+
+#. module: sale_payment_options
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.report_saleorder_payment_options_document
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard_line__total_per_installment
+msgid "Total per installment"
+msgstr "Total por cuota"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard_line__wizard_id
+msgid "Wizard"
+msgstr "Asistente"

--- a/sale_payment_options/models/__init__.py
+++ b/sale_payment_options/models/__init__.py
@@ -1,0 +1,3 @@
+from . import sale_payment_option
+from . import sale_payment_option_template
+from . import sale_order

--- a/sale_payment_options/models/sale_order.py
+++ b/sale_payment_options/models/sale_order.py
@@ -1,0 +1,87 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    payment_option_ids = fields.One2many(
+        "sale.payment.option",
+        "sale_order_id",
+        string="Payment Options",
+    )
+    payment_option_template_id = fields.Many2one("sale.payment.option.template", string="Payment Option Template")
+
+    def action_open_payment_option_wizard(self):
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "sale.payment.option.wizard",
+            "view_mode": "form",
+            "target": "new",
+            "context": {
+                "default_sale_order_id": self.id,
+            },
+        }
+
+    @api.onchange("payment_option_template_id")
+    def _onchange_payment_option_template_id(self):
+        if not self.payment_option_template_id:
+            self.payment_option_ids = [fields.Command.clear()]
+            return
+
+        invalid_options = []
+        for option in self.payment_option_template_id.payment_option_ids:
+            total_percentage = sum(opt.get("percentage") for opt in option.options_json)
+            if abs(total_percentage - 100) > 0.01:
+                option_names = [opt.get("card_installment") for opt in option.options_json]
+                invalid_options.append(f"{', '.join(option_names)}: {total_percentage}%")
+
+        if invalid_options:
+            return {
+                "warning": {
+                    "title": _("Invalid Template Configuration"),
+                    "message": _("The following options don't sum to 100%%:\n%s") % "\n".join(invalid_options),
+                }
+            }
+
+        self.payment_option_ids = [fields.Command.clear()]
+        for option in self.payment_option_template_id.payment_option_ids:
+            self._create_payment_option_from_template(option)
+
+    def _create_payment_option_from_template(self, template_option):
+        wizard_lines = [
+            (
+                0,
+                0,
+                {
+                    "card_installment_id": opt.get("card_installment_id"),
+                    "percentage": opt.get("percentage") / 100,
+                },
+            )
+            for opt in template_option.options_json
+        ]
+        wizard = self.env["sale.payment.option.wizard"].create(
+            {
+                "sale_order_id": self._origin.id,
+                "line_ids": wizard_lines,
+            }
+        )
+        wizard.confirm()
+
+    @api.constrains("payment_option_ids")
+    def _check_payment_options_percentages(self):
+        for order in self:
+            invalid_options = []
+            for option in order.payment_option_ids:
+                if option.options_json:
+                    total_percentage = sum(opt.get("percentage") for opt in option.options_json)
+                    if abs(total_percentage - 100) > 0.01:
+                        option_names = [opt.get("card_installment") for opt in option.options_json]
+                        invalid_options.append(f"'{', '.join(option_names)}': {total_percentage}%")
+
+            if invalid_options:
+                raise ValidationError(
+                    _("The following payment options have invalid percentage totals (must be exactly 100%%):\n%s")
+                    % "\n".join(invalid_options)
+                )

--- a/sale_payment_options/models/sale_payment_option.py
+++ b/sale_payment_options/models/sale_payment_option.py
@@ -1,0 +1,117 @@
+from odoo import api, fields, models
+
+
+class SalePaymentOption(models.Model):
+    _name = "sale.payment.option"
+    _description = "Sale payment option"
+    _order = "sequence"
+
+    sequence = fields.Integer(default=10)
+    payment_option_template_id = fields.Many2one("sale.payment.option.template")
+    sale_order_id = fields.Many2one("sale.order", ondelete="cascade")
+    options_json = fields.Json(readonly=False, compute="_compute_options_json", store=True)
+    options_json_rendered = fields.Html(string="Details", compute="_compute_options_json_rendered", store=False)
+
+    @api.depends("sale_order_id.amount_total")
+    def _compute_options_json(self):
+        for rec in self:
+            if not rec.sale_order_id or not rec.options_json:
+                continue
+
+            updated_options = []
+            for opt in rec.options_json:
+                updated_opt = dict(opt)
+                card_installment_id = updated_opt.get("card_installment_id")
+                card_installment = self.env["account.card.installment"].browse(card_installment_id)
+                if card_installment.exists():
+                    order_amount = rec.sale_order_id.amount_total * updated_opt.get("percentage") / 100
+                    mapped_values = card_installment.map_installment_values(order_amount)
+                    subtotal = mapped_values.get("amount")
+                    updated_opt.update(
+                        {"subtotal": subtotal, "total_per_installment": subtotal / updated_opt.get("installment_qty")}
+                    )
+                updated_options.append(updated_opt)
+            rec.options_json = updated_options
+
+    def _render_options_json_table(self, template_mode=False):
+        self.ensure_one()
+        if not self.options_json:
+            return ""
+
+        if template_mode:
+            return self._render_template_table()
+        return self._render_full_table()
+
+    def _render_template_table(self):
+        table_parts = [
+            '<table class="table table-sm table-bordered mb-2">',
+            "<thead><tr><th>% OV</th><th>Plan de cuotas</th><th>Recargo</th></tr></thead>",
+            "<tbody>",
+        ]
+
+        for opt in self.options_json:
+            table_parts.append(
+                f'<tr>'
+                f'<td>{opt.get("percentage")}%</td>'
+                f'<td>{opt.get("card_installment")}</td>'
+                f'<td>{opt.get("surcharge")}%</td>'
+                f'</tr>'
+            )
+
+        table_parts.extend(["</tbody>", "</table>"])
+        return "".join(table_parts)
+
+    def _render_full_table(self):
+        table_parts = [
+            '<table class="table table-sm table-bordered mb-2">',
+            "<thead><tr>",
+            '<th style="width:10%">% OV</th>'
+            '<th style="width:30%">Plan de cuotas</th>'
+            '<th style="width:10%">Recargo</th>'
+            '<th style="width:20%">Subtotal</th>'
+            '<th style="width:20%">Total por cuota</th>'
+            '<th style="width:10%">Cantidad de cuotas</th>'
+            "</tr></thead><tbody>",
+        ]
+
+        total_subtotal = 0
+        for opt in self.options_json:
+            subtotal = opt.get("subtotal", 0)
+            total_subtotal += subtotal or 0
+
+            table_parts.append(
+                f'<tr>'
+                f'<td style="width:10%">{opt.get("percentage", "")}%</td>'
+                f'<td style="width:30%">{opt.get("card_installment", "")}</td>'
+                f'<td style="width:10%">{opt.get("surcharge", "")}%</td>'
+                f'<td style="width:20%">{self._format_currency(subtotal)}</td>'
+                f'<td style="width:20%">{self._format_currency(opt.get("total_per_installment"))}</td>'
+                f'<td style="width:10%">{opt.get("installment_qty") or "-"}</td>'
+                f'</tr>'
+            )
+
+        table_parts.extend(
+            [
+                "</tbody>",
+                "<tfoot><tr>",
+                '<td colspan="3"><b>Total</b></td>',
+                f"<td><b>{self._format_currency(total_subtotal)}</b></td>",
+                '<td colspan="2"></td>',
+                "</tr></tfoot>",
+                "</table>",
+            ]
+        )
+
+        return "".join(table_parts)
+
+    def _compute_options_json_rendered(self):
+        for rec in self:
+            template_mode = bool(rec.payment_option_template_id)
+            rec.options_json_rendered = rec._render_options_json_table(template_mode=template_mode)
+
+    def _format_currency(self, amount):
+        if not amount:
+            return ""
+        if self.sale_order_id and self.sale_order_id.currency_id:
+            return self.sale_order_id.currency_id.format(amount)
+        return f"{amount:.2f}"

--- a/sale_payment_options/models/sale_payment_option_template.py
+++ b/sale_payment_options/models/sale_payment_option_template.py
@@ -1,0 +1,23 @@
+from odoo import fields, models
+
+
+class SalePaymentOptionTemplate(models.Model):
+    _name = "sale.payment.option.template"
+    _description = "Sale payment option template"
+    _order = "name"
+
+    name = fields.Char(required=True, translate=True)
+    payment_option_ids = fields.One2many("sale.payment.option", "payment_option_template_id")
+    active = fields.Boolean(default=True)
+
+    def action_open_payment_option_wizard(self):
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "sale.payment.option.wizard",
+            "view_mode": "form",
+            "target": "new",
+            "context": {
+                "default_payment_option_template_id": self.id,
+            },
+        }

--- a/sale_payment_options/report/ir_actions_report.xml
+++ b/sale_payment_options/report/ir_actions_report.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="action_report_saleorder_payment_options" model="ir.actions.report">
+        <field name="name">Quotation / Order (Payment Options)</field>
+        <field name="model">sale.order</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">sale_payment_options.report_saleorder_payment_options</field>
+        <field name="report_file">sale_payment_options.report_saleorder_payment_options</field>
+        <field name="print_report_name">(object.state in ('draft', 'sent') and 'Quotation - %s' % (object.name)) or 'Order - %s' % (object.name)</field>
+        <field name="binding_model_id" ref="sale.model_sale_order"/>
+        <field name="binding_type">report</field>
+    </record>
+</odoo>

--- a/sale_payment_options/report/sale_order_payment_options_report.xml
+++ b/sale_payment_options/report/sale_order_payment_options_report.xml
@@ -1,0 +1,67 @@
+<odoo>
+    <template id="report_saleorder_payment_options">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="doc">
+                <t t-call="sale_payment_options.report_saleorder_payment_options_document" t-lang="doc.partner_id.lang"/>
+            </t>
+        </t>
+    </template>
+
+    <template id="report_saleorder_payment_options_document" inherit_id="sale.report_saleorder_document">
+        <xpath expr="//div[@name='so_total_summary']" position="attributes">
+            <attribute name="style">display: none;</attribute>
+        </xpath>
+        <xpath expr="//div[@name='so_total_summary']" position="after">
+            <t t-if="doc.payment_option_ids">
+                <h3>Payment Options</h3>
+                <div>
+                    <table class="o_has_total_table table o_main_table table-borderless">
+                        <thead style="display: table-row-group">
+                            <tr>
+                                <th class="text-start">Op.</th>
+                                <th class="text-start">% OV</th>
+                                <th class="text-end text-nowrap">Installment plan</th>
+                                <th class="text-end">Surcharge</th>
+                                <th class="text-end">Subtotal</th>
+                                <th class="text-end">Total per installment</th>
+                                <th class="text-end">Installment quantity</th>
+                            </tr>
+                        </thead>
+                        <t t-set="op_index" t-value="1"/>
+                        <t t-foreach="doc.payment_option_ids" t-as="opt">
+                            <t>
+                                <tr>
+                                    <td colspan="7" style="border-top:1px solid #111827"></td>
+                                </tr>
+                            </t>
+                            <tbody>
+                                <t t-set="subtotal" t-value="0"/>
+                                <t t-set="rowspan" t-value="len(opt.options_json) if opt.options_json else 1"/>
+                                <t t-foreach="opt.options_json" t-as="item" t-index="item_index">
+                                    <tr>
+                                        <td class="text-start" t-if="item_index == 0" t-att-rowspan="rowspan"><t t-esc="op_index"/></td>
+                                        <td class="text-start" t-if="item_index != 0" style="display:none"></td> <!-- The following hidden cell is used to keep table alignment when using rowspan for the index column. -->
+                                        <td class="text-start"><t t-esc="item.get('percentage')"/>%</td>
+                                        <td class="text-end text-nowrap"><t t-esc="item.get('card_installment')"/></td>
+                                        <td class="text-end"><t t-esc="item.get('surcharge')"/>%</td>
+                                        <td class="text-end"><t t-esc="item.get('subtotal')"/></td>
+                                        <td class="text-end"><t t-esc="item.get('total_per_installment')"/></td>
+                                        <td class="text-end"><t t-esc="item.get('installment_qty')"/></td>
+                                    </tr>
+                                    <t t-set="subtotal" t-value="subtotal + item.get('subtotal')"/>
+                                </t>
+                                <tr class="fw-bold">
+                                    <td colspan="4" class="text-end">Total</td>
+                                    <td class="text-end"><span t-esc="'%.2f' % subtotal"/></td>
+                                    <td></td>
+                                    <td></td>
+                                </tr>
+                                <t t-set="op_index" t-value="op_index + 1"/>
+                            </tbody>
+                        </t>
+                    </table>
+                </div>
+            </t>
+        </xpath>
+    </template>
+</odoo>

--- a/sale_payment_options/security/ir.model.access.csv
+++ b/sale_payment_options/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sale_payment_option,sale.payment.option,model_sale_payment_option,base.group_user,1,1,1,1
+access_sale_payment_option_template,sale.payment.option.template,model_sale_payment_option_template,base.group_user,1,1,1,1
+access_sale_payment_option_wizard,sale.payment.option.wizard,model_sale_payment_option_wizard,base.group_user,1,1,1,1
+access_sale_payment_option_wizard_line,sale.payment.option.wizard.line,model_sale_payment_option_wizard_line,base.group_user,1,1,1,1

--- a/sale_payment_options/static/src/css/sale_payment_options.css
+++ b/sale_payment_options/static/src/css/sale_payment_options.css
@@ -1,0 +1,9 @@
+th[data-name="options_json_rendered"],
+td[data-name="options_json_rendered"] {
+    width: 80% !important;
+}
+
+th[data-name="sequence"],
+td[data-name="sequence"] {
+    width: 10% !important;
+}

--- a/sale_payment_options/views/sale_order_views.xml
+++ b/sale_payment_options/views/sale_order_views.xml
@@ -1,0 +1,25 @@
+<odoo>
+    <record id="view_order_form_inherit_payment_options" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.payment.options</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <notebook position="inside">
+                <page string="Payment Options" groups="base.group_user">
+                    <group>
+                        <group>
+                            <field name="payment_option_template_id" string="Payment Option Template" readonly="state == 'sale'"/>
+                            <button name="action_open_payment_option_wizard" type="object" string="Add Payment Option" class="oe_highlight" invisible="state == 'sale'"/>
+                        </group>
+                        <field name="payment_option_ids" force_save="1">
+                            <list create="false" editable="bottom">
+                                <field name="sequence" widget="handle"/>
+                                <field name="options_json_rendered" string="Details"/>
+                            </list>
+                        </field>
+                    </group>
+                </page>
+            </notebook>
+        </field>
+    </record>
+</odoo>

--- a/sale_payment_options/views/sale_payment_option_template_views.xml
+++ b/sale_payment_options/views/sale_payment_option_template_views.xml
@@ -1,0 +1,47 @@
+<odoo>
+    <record id="view_sale_payment_option_template_list" model="ir.ui.view">
+        <field name="name">sale.payment.option.template.tree</field>
+        <field name="model">sale.payment.option.template</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="name"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_sale_payment_option_template_form" model="ir.ui.view">
+        <field name="name">sale.payment.option.template.form</field>
+        <field name="model">sale.payment.option.template</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button name="action_open_payment_option_wizard" type="object" string="Add Payment Option" class="oe_highlight"/>
+                    </div>
+                    <group>
+                        <field name="name"/>
+                    </group>
+                    <field name="payment_option_ids">
+                        <list create="false" editable="bottom">
+                            <field name="sequence" widget="handle"/>
+                            <field name="options_json_rendered" string="Details"/>
+                        </list>
+                    </field>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_sale_payment_option_template" model="ir.actions.act_window">
+        <field name="name">Payment Option Templates</field>
+        <field name="res_model">sale.payment.option.template</field>
+        <field name="view_mode">list,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create payment option templates to reuse payment configurations in sales orders.
+            </p>
+        </field>
+    </record>
+
+    <menuitem id="menu_sale_payment_option_template" name="Payment Option Templates" parent="sale.menu_sale_config" sequence="100" action="action_sale_payment_option_template"/>
+</odoo>

--- a/sale_payment_options/wizard/__init__.py
+++ b/sale_payment_options/wizard/__init__.py
@@ -1,0 +1,2 @@
+from . import sale_payment_option_wizard
+from . import sale_payment_option_wizard_line

--- a/sale_payment_options/wizard/sale_payment_option_wizard.py
+++ b/sale_payment_options/wizard/sale_payment_option_wizard.py
@@ -1,0 +1,34 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class SalePaymentOptionWizard(models.TransientModel):
+    _name = "sale.payment.option.wizard"
+    _description = "Sale payment option wizard"
+
+    sale_order_id = fields.Many2one("sale.order", string="Sales Order")
+    payment_option_template_id = fields.Many2one("sale.payment.option.template")
+    total = fields.Monetary(string="Order Total", related="sale_order_id.amount_total")
+    currency_id = fields.Many2one("res.currency", string="Currency", related="sale_order_id.currency_id")
+    line_ids = fields.One2many("sale.payment.option.wizard.line", "wizard_id", string="Payment Lines")
+
+    @api.constrains("line_ids")
+    def _check_percentages(self):
+        for wizard in self:
+            percentage_total = sum(line.percentage for line in wizard.line_ids)
+            if percentage_total != 1:
+                raise ValidationError(_("The sum of the percentages must be exactly 100."))
+
+    def confirm(self):
+        self.ensure_one()
+        template_mode = bool(self.payment_option_template_id)
+        options = self.line_ids.get_json_list(template_mode=template_mode)
+        vals = {
+            "options_json": options,
+        }
+        if self.sale_order_id:
+            vals["sale_order_id"] = self.sale_order_id.id
+        if self.payment_option_template_id:
+            vals["payment_option_template_id"] = self.payment_option_template_id.id
+        self.env["sale.payment.option"].create(vals)
+        return {"type": "ir.actions.act_window_close"}

--- a/sale_payment_options/wizard/sale_payment_option_wizard_line.py
+++ b/sale_payment_options/wizard/sale_payment_option_wizard_line.py
@@ -1,0 +1,60 @@
+from odoo import api, fields, models
+from odoo.tools import float_round
+
+
+class SalePaymentOptionWizardLine(models.TransientModel):
+    _name = "sale.payment.option.wizard.line"
+    _description = "Sale payment option wizard line"
+
+    wizard_id = fields.Many2one("sale.payment.option.wizard", required=True, ondelete="cascade")
+    percentage = fields.Float(required=True)
+    card_installment_id = fields.Many2one("account.card.installment", string="Installment Plan", required=True)
+    surcharge_coefficient = fields.Float(related="card_installment_id.surcharge_coefficient")
+    installment_qty = fields.Integer(related="card_installment_id.divisor")
+    subtotal = fields.Monetary(compute="_compute_subtotal")
+    currency_id = fields.Many2one(related="wizard_id.currency_id")
+    total_per_installment = fields.Monetary(compute="_compute_total_per_installment", string="Total per Installment")
+
+    @api.depends("percentage", "wizard_id.total")
+    def _compute_subtotal(self):
+        lines = self.filtered(lambda line: line.percentage and line.wizard_id.total)
+        for line in lines:
+            line.subtotal = line.card_installment_id.map_installment_values(line.wizard_id.total * line.percentage).get(
+                "amount"
+            )
+        (self - lines).subtotal = 0.0
+
+    @api.depends("subtotal", "card_installment_id")
+    def _compute_total_per_installment(self):
+        lines = self.filtered(lambda line: line.subtotal and line.card_installment_id and line.installment_qty > 0)
+        for line in lines:
+            line.total_per_installment = line.subtotal / line.installment_qty
+        (self - lines).total_per_installment = 0.0
+
+    def get_json_dict(self, template_mode=False):
+        self.ensure_one()
+        digits = self.fields_get(["surcharge_coefficient"])["surcharge_coefficient"].get("digits", (16, 2))[1]
+        surcharge = float_round((self.surcharge_coefficient - 1) * 100, precision_digits=digits)
+        total_per_installment = (
+            float_round(self.subtotal / self.installment_qty, precision_digits=2) if self.installment_qty else 0.0
+        )
+        if template_mode:
+            return {
+                "percentage": self.percentage * 100,
+                "card_installment": self.card_installment_id.display_name,
+                "card_installment_id": self.card_installment_id.id,
+                "surcharge": surcharge,
+                "installment_qty": self.installment_qty,
+            }
+        return {
+            "percentage": self.percentage * 100,
+            "card_installment": self.card_installment_id.display_name,
+            "card_installment_id": self.card_installment_id.id,
+            "surcharge": surcharge,
+            "subtotal": self.subtotal,
+            "total_per_installment": total_per_installment,
+            "installment_qty": self.installment_qty,
+        }
+
+    def get_json_list(self, template_mode=False):
+        return [line.get_json_dict(template_mode=template_mode) for line in self]

--- a/sale_payment_options/wizard/sale_payment_option_wizard_views.xml
+++ b/sale_payment_options/wizard/sale_payment_option_wizard_views.xml
@@ -1,0 +1,27 @@
+<odoo>
+    <record id="view_sale_payment_option_wizard_form" model="ir.ui.view">
+        <field name="name">sale.payment.option.wizard.form</field>
+        <field name="model">sale.payment.option.wizard</field>
+        <field name="arch" type="xml">
+            <form>
+                <field name="sale_order_id" invisible="1"/>
+                <field name="payment_option_template_id" invisible="1"/>
+                <field name="total" invisible="1"/>
+                <field name="line_ids">
+                    <list editable="bottom">
+                        <field name="card_installment_id"/>
+                        <field name="percentage" widget="percentage"/>
+                        <field name="surcharge_coefficient"/>
+                        <field name="installment_qty" string="Installment"/>
+                        <field name="subtotal" column_invisible="parent.payment_option_template_id"/>
+                        <field name="total_per_installment" column_invisible="parent.payment_option_template_id"/>
+                    </list>
+                </field>
+                <footer>
+                    <button string="Confirm" type="object" name="confirm" class="btn-primary"/>
+                    <button string="Cancel" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Introduced a new module to manage and display multiple payment options on quotations and sales orders.
- Implemented models for payment options, templates, and wizards to facilitate payment configuration.
- Added views for managing payment options and templates within the sales order interface.
- Created reports to display payment options in sales order documents.