### PR TITLE
[FIX] sale_order_type_ux: browse fiscal position from second company

### DIFF
--- a/sale_order_type_ux/models/sale_order.py
+++ b/sale_order_type_ux/models/sale_order.py
@@ -39,7 +39,7 @@ class SaleOrder(models.Model):
             if "narration" in res and not res["narration"]:
                 del res["narration"]
             so_fiscal_position = self.env["account.fiscal.position"].browse(res["fiscal_position_id"])
-            if so_fiscal_position.company_id and so_fiscal_position.company_id != company:
+            if not so_fiscal_position or (so_fiscal_position.company_id and so_fiscal_position.company_id != company):
                 res["fiscal_position_id"] = (
                     self.env["account.fiscal.position"]
                     .with_company(company.id)


### PR DESCRIPTION
The original code checked if the fiscal position's company was different from the sales order's company. If the second company (the invoice company) did not have a fiscal position, nothing was assigned.

I added a condition so that if no fiscal position is defined, it will always look for the fiscal position of the invoice company.