### PR TITLE
[FIX] sale_three_discounts: remove discount field

### DIFF
--- a/sale_three_discounts/__manifest__.py
+++ b/sale_three_discounts/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Sale Three Discounts",
-    "version": "18.0.1.2.0",
+    "version": "18.0.1.3.0",
     "category": "Sales Management",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/sale_three_discounts/models/sale_order_line.py
+++ b/sale_three_discounts/models/sale_order_line.py
@@ -18,7 +18,6 @@ class SaleOrderLine(models.Model):
     discount3 = fields.Float(
         "Disc. 3 (%)", digits="Discount", compute="_compute_discount", precompute=True, store=True, readonly=False
     )
-    discount = fields.Float(readonly=True)
 
     @api.constrains("discount1", "discount2", "discount3")
     def check_discount_validity(self):


### PR DESCRIPTION
Remuevo esta redefinición y la dejo solo por vista ya que había errores al crear la orden de venta con los descuentos. Cuando se guardaba la OV el campo descuento pasaba a 0, el problema viene desde _prepare_create_values que cuando hay un campo precompute=True y readonly=True entonces limpia lo que va en vals e intenta calcular el valor del descuento (esto lo pone en 0).

Tiene sus problemas ya que al exportar/importar podríamos escribir en el campo discount.