### PR TITLE
[FIX] sale_three_discounts: Filter out invoice and refund types in discount computation

### DIFF
--- a/sale_three_discounts/models/account_move_line.py
+++ b/sale_three_discounts/models/account_move_line.py
@@ -31,7 +31,7 @@ class AccountMoveLine(models.Model):
 
     @api.depends('discount1', 'discount2', 'discount3')
     def _compute_discount(self):
-        for line in self:
+        for line in self.filtered(lambda x: x.move_type not in ('in_invoice', 'in_refund')):
             discount_factor = 1.0
             for discount in [line.discount1, line.discount2, line.discount3]:
                 discount_factor *= (100.0 - discount) / 100.0


### PR DESCRIPTION


When discount is set from a purchase order, the system should not replace with the discount computation.

This code was in 16 and deleted in migration of 17 by mistake.

https://github.com/ingadhoc/sale/blob/966f3f2d7b1cae18df45dc2508d70e2b805912db/sale_three_discounts/models/account_invoice_line.py#L72C9-L72C92