### PR TITLE
[FIX] portal_sale_distributor: fix en s.o name

### DIFF
--- a/portal_sale_distributor/models/sale_order.py
+++ b/portal_sale_distributor/models/sale_order.py
@@ -87,3 +87,15 @@ class SaleOrder(models.Model):
     def action_update_prices(self):
         self = self.sudo()
         super().action_update_prices()
+    
+    def name_get(self):
+        """Asegurar que los usuarios portal vean el nombre correcto"""
+        if self.env.user.has_group('portal_sale_distributor.group_portal_backend_distributor'):
+            result = []
+            for order in self:
+                # Sudo para leer el nombre generado por la secuencia
+                sudo_order = order.sudo()
+                name = sudo_order.name
+                result.append((order.id, name))
+            return result
+        return super().name_get()


### PR DESCRIPTION
The problem is that when a portal distributor user creates a sales order in the second company, the order name appears as 'New' in the portal view, even though the correct name is assigned in the backend.

With this method, we ensure that the correct name is displayed.