### PR TITLE
[FIX] sale_order_type_automation: add condition to force compute move names for invoice lines when name of the invoice is set

### DIFF
--- a/sale_order_type_automation/models/sale_order.py
+++ b/sale_order_type_automation/models/sale_order.py
@@ -32,6 +32,12 @@ class SaleOrder(models.Model):
                     rec.env.cr.commit()
                 try:
                     invoices.sudo().action_post()
+                    if (
+                        invoices.name
+                        and not invoices.line_ids.mapped("move_name")
+                        and invoices.name not in invoices.line_ids.mapped("move_name")
+                    ):
+                        invoices.env.add_to_compute(invoices.line_ids._fields["move_name"], invoices.line_ids)
                 except Exception as error:
                     rec.env.cr.rollback()
                     if not self._context.get("commit_invoice_automation"):


### PR DESCRIPTION
Hola si! no paso que ese campo related de move_name cuando el picking se devide en dos el segundo no queda computado para el caso del aml por mas que el move si tenga el name
esto debugeando en los metodos de odoo y no encontre porque pasaba
llega el mismo contexto que en la primera y se llama directamente a escribirse ese campo ya que lo detecta como related, el tema es que no lo hace

