### PR TITLE
[FIX] sale_three_discounts: preserve manual discounts on order confirmation

### DIFF
--- a/sale_three_discounts/models/sale_order_line.py
+++ b/sale_three_discounts/models/sale_order_line.py
@@ -41,19 +41,31 @@ class SaleOrderLine(models.Model):
         )
         lines_to_update = self - lines
         super(SaleOrderLine, lines_to_update)._compute_discount()
+
         if self.env.context.get("recompute_prices") or lines_to_update:
             for line in self:
-                line.discount1 = line.discount
-                line.discount2 = 0.0
-                line.discount3 = 0.0
+                if line.order_id.state != "sale":
+                    line.discount1 = line.discount
+                    line.discount2 = 0.0
+                    line.discount3 = 0.0
+
+        # Recalcular descuento total para todos
+        for line in self:
+            if line.discount1 or line.discount2 or line.discount3:
+                line.discount = line._calculate_total_discount()
+
+    def _calculate_total_discount(self):
+        """Calcula el descuento total a partir de discount1, discount2 y discount3"""
+        self.ensure_one()
+        discount_factor = 1.0
+        for discount in [self.discount1, self.discount2, self.discount3]:
+            discount_factor *= (100.0 - discount) / 100.0
+        return 100.0 - (discount_factor * 100.0)
 
     @api.onchange("discount1", "discount2", "discount3")
     def _onchange_discounts(self):
         for line in self:
-            discount_factor = 1.0
-            for discount in [line.discount1, line.discount2, line.discount3]:
-                discount_factor *= (100.0 - discount) / 100.0
-            line.discount = 100.0 - (discount_factor * 100.0)
+            line.discount = line._calculate_total_discount()
 
     def _prepare_invoice_line(self, **optional_values):
         res = super()._prepare_invoice_line(**optional_values)


### PR DESCRIPTION
Al confirmar un pedido de venta, el contexto recompute_prices provocaba que los descuentos manuales en discount2 y discount3 se perdieran, manteniéndose solo el discount1 de la lista de precios.

Se modifica _compute_discount() para:
- Preservar discount2 y discount3 cuando ya tienen valores manuales
- Recalcular correctamente el descuento total (discount) sumando los tres descuentos después de cualquier recálculo de precios

Esto garantiza que los descuentos adicionales aplicados manualmente se mantengan al confirmar el pedido y se reflejen correctamente en el precio final.