### PR TITLE
[FIX] sale_stock_ux: fix singleton error when creating exchange return

### DIFF
--- a/sale_stock_ux/wizards/stock_return_picking.py
+++ b/sale_stock_ux/wizards/stock_return_picking.py
@@ -24,8 +24,8 @@ class StockReturnPicking(models.TransientModel):
         return result
 
     def action_create_exchanges(self):
-        if self.filtered(lambda m: m.product_return_moves.to_refund):
-            raise UserError(_("You cannot create exchanges for moves without refunds."))
+        if any(self.product_return_moves.mapped("to_refund")):
+            raise UserError(_("You cannot create exchanges for return lines marked to refund."))
         return super(StockReturnPicking, self.with_context(is_exchange_move=True)).action_create_exchanges()
 
 


### PR DESCRIPTION
Avoid "Expected singleton" error on stock.return.picking when multiple return lines exist. 
Updated condition to use any(mapped('to_refund')) and clarified UserError message.