### PR TITLE
[FIX] sale_gathering:ensure reversed_entry_id is handled correctly during posting

### DIFF
--- a/sale_gathering/models/account_move.py
+++ b/sale_gathering/models/account_move.py
@@ -27,7 +27,18 @@ class AccountMove(models.Model):
 
     def _post(self, soft=True):
         # Odoo only auto-reconciles when credit note is posted after invoice, not vice versa
+
+        reversed_entries = {}
+        # Temporarily unlink reversed_entry_id to avoid validation error when posting invoices with afip connecting journal
+        # as the reversed entry is still in draft state and l10n_latam_document_number is not set yet, this leads to a validation error.
+        for move in self.filtered(lambda m: m.reversed_entry_id and m.reversed_entry_id.state == "draft"):
+            reversed_entries[move] = move.reversed_entry_id
+            move.reversed_entry_id = False
         result = super()._post(soft=soft)
+
+        for move, rev in reversed_entries.items():
+            move.reversed_entry_id = rev
+
         for move in self.filtered(lambda m: m.state == "posted" and m.move_type == "out_invoice"):
             is_gathering_sale = any(
                 line.sale_line_ids.order_id.is_gathering for line in move.invoice_line_ids if line.sale_line_ids

--- a/sale_gathering/models/sale_order.py
+++ b/sale_gathering/models/sale_order.py
@@ -175,8 +175,10 @@ class SaleOrder(models.Model):
                         moves_to_switch.action_switch_move_type()
                 if downpayment_invoice.move_type == "out_refund":
                     downpayment_invoice.reversed_entry_id = products_invoice
+                    invoices.write({"ref": "Canje"})
                 else:
                     products_invoice.reversed_entry_id = downpayment_invoice
+                    invoices.write({"ref": "Devolución Canje"})
             else:
                 invoices = super()._create_invoices(final=True, grouped=grouped, date=date)
             return invoices

--- a/sale_gathering/wizards/sale_advance_payment_inv.py
+++ b/sale_gathering/wizards/sale_advance_payment_inv.py
@@ -34,3 +34,9 @@ class SaleAdvancePaymentInvWizard(models.TransientModel):
                 raise ValidationError(
                     _("The 'Factura en cero descontando acopio' method can only be used for gathering sales.")
                 )
+
+    def _create_invoices(self, sale_orders):
+        invoice = super()._create_invoices(sale_orders)
+        if invoice.invoice_line_ids.is_downpayment:
+            invoice.write({"ref": "Acopio"})
+        return invoice


### PR DESCRIPTION


This way we only assign the reversed entry when it is posted