### PR TITLE
[FIX] sale_delivery_ux: ensure qty_delivered on validate regardless of tracking_ref

### DIFF
--- a/sale_delivery_ux/models/stock_picking.py
+++ b/sale_delivery_ux/models/stock_picking.py
@@ -8,7 +8,7 @@ from odoo import models
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    def _add_delivery_cost_to_so(self):
+    def _action_done(self):
         """
         We set qty delivered 1 for every sale order line that:
         * is a delivery
@@ -19,10 +19,11 @@ class StockPicking(models.Model):
         button or automatically by the picking and that the user has not change
         for any reason
         """
-        super()._add_delivery_cost_to_so()
+        res = super()._action_done()
         deliver_lines = self.sale_id.order_line.filtered(
             lambda x: (
                 x.is_delivery and not x.qty_delivered and x.product_id.type == "service" and x.product_uom_qty == 1.0
             )
         )
         deliver_lines.update({"qty_delivered": 1.0})
+        return res


### PR DESCRIPTION
In Odoo 18, the native _add_delivery_cost_to_so() method is only called
from send_to_shipper(), which is only executed when carrier_tracking_ref is empty.

When carrier_tracking_ref is manually filled before validating the picking,
send_to_shipper() is skipped, so _add_delivery_cost_to_so() never executes,
and delivery lines don't get qty_delivered set to 1.0.

This caused that:
- Without carrier_tracking_ref: qty_delivered was increased
- With carrier_tracking_ref: qty_delivered stayed at 0, preventing invoicing

Solution: Move the logic from _add_delivery_cost_to_so() to _action_done() to ensure delivery lines always get qty_delivered = 1.0 when the picking is validated, regardless of whether carrier_tracking_ref is filled or not. 

This guarantees consistent behavior in both scenarios.