### PR TITLE
[FIX] sale_order_type_ux: update post_init_hook to set type_id for 's…

### DIFF
--- a/sale_order_type_ux/hooks.py
+++ b/sale_order_type_ux/hooks.py
@@ -12,7 +12,7 @@ def post_init_hook(env):
         """
         UPDATE sale_order
         SET type_id = %s
-        WHERE state IN ('sale', 'done')
+        WHERE state IN ('sale', 'cancel')
           AND type_id IS NULL
     """,
         (default_sale_order_type.id,),


### PR DESCRIPTION
…ale' and 'cancel' states