### PR TITLE
[IMP] sale_ux: always allow to recompute taxes

### DIFF
--- a/sale_ux/models/sale_order.py
+++ b/sale_ux/models/sale_order.py
@@ -93,7 +93,6 @@ class SaleOrder(models.Model):
         self.ensure_one()
         lines_to_recompute = self.order_line.filtered(lambda line: not line.display_type)
         lines_to_recompute._compute_tax_id()
-        self.show_update_fpos = False
 
     def action_cancel(self):
         invoice_lines = self.sudo().env["account.move.line"].search([("sale_line_ids", "in", self.order_line.ids)])

--- a/sale_ux/views/sale_order_views.xml
+++ b/sale_ux/views/sale_order_views.xml
@@ -28,6 +28,11 @@
                 <attribute name="optional">hide</attribute>
             </xpath>
 
+            <!-- lo dejamos siempre visible para que si el cliente modifica cosas por edicion masiva, expo/impo u otras o manualmente, pueda siempre re-computar según la FP -->
+            <button name="action_update_taxes" position="attributes">
+                <attribute name="invisible">state not in ['draft', 'sent']</attribute>
+            </button>
+
             <xpath expr="//field[@name='order_line']/list" position="attributes">
                 <attribute name="limit">40</attribute>
             </xpath>


### PR DESCRIPTION
El boton no molesta y puede ser util en escenarios donde no se recomputa automaticamente (por ej. si usuario cambio manualmente taxes y quiere corregir, si e edito fiscal position por shell u otro metodo que no llama onchange)