### PR TITLE
[FIX] sale_gathering_automation: add sudo to advance payment action read

### DIFF
--- a/sale_gathering_automation/models/sale_order.py
+++ b/sale_gathering_automation/models/sale_order.py
@@ -27,7 +27,7 @@ class SaleOrder(models.Model):
             self.run_invoicing_atomation()
             return self.action_view_invoice()
 
-        return self.env.ref("sale.action_view_sale_advance_payment_inv").read()[0]
+        return self.env.ref("sale.action_view_sale_advance_payment_inv").sudo().read()[0]
 
     def run_invoicing_atomation(self):
         gathering_lines = self.filtered("is_gathering")


### PR DESCRIPTION
Add sudo() when reading the advance payment invoice action to avoid access rights errors for users without full sale configuration permissions.