### PR TITLE
[FIX] sale_stock_ux: self.product_uom → self.product_uom_id (v19 compat)

### DIFF
--- a/sale_stock_ux/models/sale_order_line.py
+++ b/sale_stock_ux/models/sale_order_line.py
@@ -59,10 +59,10 @@ class SaleOrderLine(models.Model):
         outgoing_moves, incoming_moves = self._get_outgoing_incoming_moves(strict=False)
         for move in outgoing_moves.filtered(lambda m: m.is_exchange_move):
             qty_to_compute = move.quantity if move.state == "done" else move.product_uom_qty
-            qty -= move.product_uom._compute_quantity(qty_to_compute, self.product_uom, rounding_method="HALF-UP")
+            qty -= move.product_uom._compute_quantity(qty_to_compute, self.product_uom_id, rounding_method="HALF-UP")
         for move in incoming_moves.filtered(lambda m: m.is_exchange_move):
             qty_to_compute = move.quantity if move.state == "done" else move.product_uom_qty
-            qty += move.product_uom._compute_quantity(qty_to_compute, self.product_uom, rounding_method="HALF-UP")
+            qty += move.product_uom._compute_quantity(qty_to_compute, self.product_uom_id, rounding_method="HALF-UP")
         return qty
 
     @api.depends()
@@ -242,7 +242,7 @@ class SaleOrderLine(models.Model):
                                 and m.to_refund
                             ),
                         }
-                        order_qty = order_line.product_uom._compute_quantity(
+                        order_qty = order_line.product_uom_id._compute_quantity(
                             order_line.product_uom_qty, relevant_bom.product_uom_id
                         )
                         quantity_returned = return_moves._compute_kit_quantities(


### PR DESCRIPTION
## Summary

In v19 the field `sale.order.line.product_uom` was renamed to `product_uom_id`. Three calls in `sale_stock_ux/models/sale_order_line.py` still used the old name on the `sale.order.line` recordset, raising `AttributeError` when the model is loaded post-migration:

```
AttributeError: 'sale.order.line' object has no attribute 'product_uom'
```

Affected methods:
- `_get_qty_procurement` (was breaking on the 2nd argument of `_compute_quantity`)
- `_compute_quantity_returned` (BOM kits branch, was breaking for orders with kit products)

## What changed

`self.product_uom` → `self.product_uom_id` and `order_line.product_uom` → `order_line.product_uom_id`.

Note: `move.product_uom` / `move_ids.product_uom` (on `stock.move`) is **still valid in v19** and was left untouched — only the sale.order.line access needed the rename.

## Reproduction

Fresh migration from v18 to v19 (`upgrade.odoo.com` test) followed by `-u all` on a database that has sale orders with exchange moves or BOM kits triggered the traceback.

## Test plan

- [x] Migrated a real production DB (v18 → v19 via upgrade.odoo.com) and ran `-u all` — without this fix the registry fails to load; with the fix it completes cleanly.
- [x] `_get_qty_procurement` returns correct quantities for exchange moves between different UoMs.