### PR TITLE
[FIX] sale_ux: keep subcontact pricelist inherited from parent on create

### DIFF
--- a/sale_ux/models/res_partner.py
+++ b/sale_ux/models/res_partner.py
@@ -17,6 +17,11 @@ class ResPartner(models.Model):
         pricelist = self.env["product.pricelist"].search([], limit=1, order="sequence")
         for partner, vals in zip(partners, vals_list):
             if "specific_property_product_pricelist" not in vals:
+                # Los subcontactos heredan la lista de precios del contacto comercial
+                # (empresa matriz) a través del mecanismo de commercial_fields de Odoo.
+                # No debemos pisar ese valor o el subcontacto perderá la herencia.
+                if partner.parent_id:
+                    continue
                 default_pricelist_id = vals.get("property_product_pricelist")
 
                 if not default_pricelist_id:


### PR DESCRIPTION
> 🎫 **Helpdesk ticket** #115317

## Changes

- [FIX] sale_ux: keep subcontact pricelist inherited from parent on create

## Problem

When creating a subcontact, Odoo's core _commercial_fields mechanism correctly syncs specific_property_product_pricelist from the parent company. However, sale_ux's create override was immediately overwriting it with None, causing the subcontact to fall back to the first pricelist in sequence instead of inheriting the parent's pricelist.

## Solution

Skip the override for partners that have a parent_id. Their pricelist is already managed by Odoo's commercial-fields sync and must not be touched.

## Related

Helpdesk ticket: #115317
Branch: 18.0-h-115317-gal
