### PR TITLE
[REF] sale_ux: rearrange deduct_price_included_taxes field location

### DIFF
--- a/sale_ux/views/account_fiscal_position_views.xml
+++ b/sale_ux/views/account_fiscal_position_views.xml
@@ -5,9 +5,9 @@
         <field name="model">account.fiscal.position</field>
         <field name="inherit_id" ref="account.view_account_position_form"/>
         <field name="arch" type="xml">
-            <field name="name" position="after">
+            <xpath expr="//field[@name='name']" position="after">
                 <field name="deduct_price_included_taxes"/>
-            </field>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Movemos campo **Deduct Price-Included Taxes** debajo del nombre de la FP
<img width="1334" height="404" alt="image" src="https://github.com/user-attachments/assets/ef897fff-18ff-46eb-95ae-23f27413e07b" />
