### PR TITLE
[IMP] sale_ux: prevent deletion of pricelists in use

### DIFF
--- a/sale_ux/README.rst
+++ b/sale_ux/README.rst
@@ -48,6 +48,7 @@ Several Improvements to sales:
 #. Allows selecting default values to assign price lists by companies and by user with the field `specific_property_product_pricelist`. It also ensures that when creating a contact, if it is not defined, it will not be set for the company you are currently on (we consider this to be an Odoo bug).
 #. Add the field "Un-invoiced" (amount_uninvoiced) in the sale order to show the uninvoiced amount.
 #. Prevents writing in certain fields in blocked sales orders.
+#. Deleting price lists with confirmed sale orders is not permitted.
 
 Installation
 ============

--- a/sale_ux/models/__init__.py
+++ b/sale_ux/models/__init__.py
@@ -12,3 +12,4 @@ from . import account_fiscal_position
 from . import res_partner
 from . import crm_team
 from . import product_template
+from . import product_pricelist

--- a/sale_ux/models/product_pricelist.py
+++ b/sale_ux/models/product_pricelist.py
@@ -1,0 +1,24 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import _, models
+from odoo.exceptions import UserError
+
+
+class ProductPricelist(models.Model):
+    _inherit = "product.pricelist"
+
+    def unlink(self):
+        confirmed_orders = self.env["sale.order"].search(
+            [("pricelist_id", "in", self.ids), ("state", "=", "sale")],
+            limit=1,
+        )
+        if confirmed_orders:
+            raise UserError(
+                _(
+                    "The price list cannot be deleted because it has confirmed sales. "
+                    "In these cases, we recommend archiving the list."
+                )
+            )
+        return super().unlink()


### PR DESCRIPTION
## Changes

- [IMP] sale_ux: prevent deletion of pricelists linked to confirmed or done sales orders by raising a UserError

## Related

Task: #67039
Branch: `18.0-t-67039-gal`