### PR TITLE
[FIX] sale_three_discounts: preserve manual discounts when confirming order

### DIFF
--- a/sale_three_discounts/models/sale_order.py
+++ b/sale_three_discounts/models/sale_order.py
@@ -8,5 +8,8 @@ from odoo import models
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
+    def action_confirm(self):
+        return super(SaleOrder, self.with_context(confirming_order=True)).action_confirm()
+
     def _recompute_prices(self):
         super(SaleOrder, self.with_context(recompute_prices=True))._recompute_prices()

--- a/sale_three_discounts/models/sale_order_line.py
+++ b/sale_three_discounts/models/sale_order_line.py
@@ -42,7 +42,9 @@ class SaleOrderLine(models.Model):
         lines_to_update = self - lines
         super(SaleOrderLine, lines_to_update)._compute_discount()
 
-        if self.env.context.get("recompute_prices") or lines_to_update:
+        if self.env.context.get("recompute_prices") or (
+            lines_to_update and not self.env.context.get("confirming_order")
+        ):
             for line in self:
                 if line.order_id.state != "sale":
                     line.discount1 = line.discount


### PR DESCRIPTION
> 🎫 **Helpdesk ticket** #116714

## Changes

- [FIX] sale_three_discounts: preserve manual discounts when confirming order

## Root cause

When confirming a sale order, `sale_loyalty.action_confirm()` calls `_update_programs_and_rewards()` which unlinks loyalty cards. That triggers an ORM `flush_all`, recomputing `_compute_discount()` while the order is still in `draft` state. Since `lines_to_update` was non-empty at that point, the condition reset `discount1/2/3` to 0 before the state transitioned to `sale`.

## Fix

- `sale_order.py`: override `action_confirm()` to inject `confirming_order=True` in the context before calling `super()`.
- `sale_order_line.py`: guard the discount reset with `not confirming_order`, so the reset only runs outside of the confirmation flow (or when `recompute_prices=True`, i.e. the user explicitly clicks "Update Prices").

## Related

Helpdesk ticket: #116714
Branch: `18.0-h-116714-gal`
