### PR TITLE
[FIX] sale_gathering_delivery: strip incompatible taxes inside _sync_dynamic_lines context

### DIFF
--- a/sale_gathering_delivery/models/account_move_line.py
+++ b/sale_gathering_delivery/models/account_move_line.py
@@ -1,25 +1,19 @@
-from odoo import api, models
+from odoo import models
 
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
-    @api.depends("sale_line_ids", "company_id")
-    def _compute_tax_ids(self):
-        super()._compute_tax_ids()
+    def _strip_gathering_incompatible_taxes(self):
+        """Remove taxes that belong to a different company than the invoice line.
+        Must be called within a _sync_dynamic_lines context so that _sync_tax_lines
+        regenerates the corresponding tax accounting entries.
+        """
         for line in self:
-            # During cross-company operations on advance invoices with delivery lines
-            # belonging to a *gathering* sale order, the native `sale` module re-injects
-            # taxes from the original (old) company. Strip them out so the ORM constraint
-            # does not raise "Incompatible companies". The multicompany wizard will
-            # re-assign the correct equivalent taxes right after.
-            # We scope this strictly to gathering orders to avoid masking legitimate
-            # cross-company tax errors on regular sale orders.
             delivery_sale_lines = line.sale_line_ids.filtered(lambda sl: sl.is_delivery)
             if not delivery_sale_lines or not line.tax_ids:
                 continue
-            is_gathering = delivery_sale_lines.order_id.filtered("is_gathering")
-            if not is_gathering:
+            if not delivery_sale_lines.order_id.filtered("is_gathering"):
                 continue
             incompatible_taxes = line.tax_ids.filtered(lambda t: t.company_id and t.company_id != line.company_id)
             if incompatible_taxes:

--- a/sale_gathering_delivery/wizards/sale_advance_payment_inv.py
+++ b/sale_gathering_delivery/wizards/sale_advance_payment_inv.py
@@ -50,11 +50,19 @@ class SaleAdvancePaymentInvWizard(models.TransientModel):
         invoice = super()._create_invoices(sale_orders)
 
         if self.advance_payment_method == "fixed" and sale_orders.filtered("is_gathering"):
+            created_lines = self.env["account.move.line"]
             for order in sale_orders.filtered("is_gathering"):
                 delivery_lines = order.order_line.filtered(lambda l: l.is_delivery and l.product_uom_qty > 0)
-                if delivery_lines:
-                    for line in delivery_lines:
-                        line_vals = self._prepare_gathering_delivery_invoice_line_vals(line, invoice)
-                        self.env["account.move.line"].with_company(invoice.company_id).create(line_vals)
+                for line in delivery_lines:
+                    line_vals = self._prepare_gathering_delivery_invoice_line_vals(line, invoice)
+                    created_lines |= self.env["account.move.line"].with_company(invoice.company_id).create(line_vals)
+
+            # Strip any incompatible taxes injected by the compute during create,
+            # inside _sync_dynamic_lines so _sync_tax_lines regenerates the
+            # tax accounting entries correctly.
+            if created_lines:
+                container = {"records": invoice}
+                with invoice._sync_dynamic_lines(container):
+                    created_lines._strip_gathering_incompatible_taxes()
 
         return invoice


### PR DESCRIPTION

The previous approach overrode _compute_tax_ids adding extra ORM dependencies (sale_line_ids, company_id) to strip taxes that belonged to a different company on gathering advance invoices with delivery lines.

This caused a subtle bug: the compute ran outside of _sync_dynamic_lines, so _sync_tax_lines had already snapshotted the base lines before the tax change happened and never regenerated the tax accounting entries (display_type='tax'), leaving the invoice unbalanced or missing tax lines.

Replace the compute override with a plain method
_strip_gathering_incompatible_taxes on account.move.line and call it from _create_invoices inside a _sync_dynamic_lines context manager. This way _sync_tax_lines observes the tax_ids mutation and correctly creates or updates the tax accounting lines.