### PR TITLE
[fix] sale_stock_ux: Skip returned quantity deduction for subscriptio…

### DIFF
--- a/sale_stock_ux/models/sale_order_line.py
+++ b/sale_stock_ux/models/sale_order_line.py
@@ -38,11 +38,24 @@ class SaleOrderLine(models.Model):
     total_reserved_quantity = fields.Float(compute="_compute_total_reserved_quantity")
     stock_by_location = fields.Text(compute="_compute_stock_by_location")
 
+    def _check_is_recurring_invoice(self):
+        self.ensure_one()
+        if (
+            self.order_id._fields.get("is_subscription")
+            and self.order_id.is_subscription
+            and self._fields.get("recurring_invoice")
+            and self.recurring_invoice
+        ):
+            return self.recurring_invoice
+        return False
+
     def _create_procurements(self, product_qty, procurement_uom, origin, values):
         self.ensure_one()
         # cancelar remanente seta la cantidad como entregada menos devuelta
         # asi que no deberia restar en ese caso
-        product_qty = product_qty - self.quantity_returned
+        # Para suscripciones: NO restar quantity_returned (ya está en qty_delivered)
+        if not self._check_is_recurring_invoice():
+            product_qty = product_qty - self.quantity_returned
         return super()._create_procurements(product_qty, procurement_uom, origin, values)
 
     @api.depends("product_id", "product_uom_qty")


### PR DESCRIPTION
…n procurements

When invoicing subscriptions with previous returns, the system was deducting quantity_returned from product_qty, resulting in negative quantities. Odoo's automatic reversal then inverted locations and picking_type, creating IN (receipts) instead of OUT (deliveries).

Added _check_is_recurring_invoice() validation to exclude subscriptions from this deduction, as their returned quantities are already accounted for in qty_delivered by sale_subscription_stock.