### PR TITLE
[IMP] sale_order_type_ux: Add warning when modifying a sale order type

### DIFF
--- a/sale_order_type_ux/i18n/es.po
+++ b/sale_order_type_ux/i18n/es.po
@@ -163,3 +163,23 @@ msgstr "Tipo de pedido de venta"
 #: model:ir.model.fields,field_description:sale_order_type_ux.field_sale_order_type__warehouse_id
 msgid "Warehouse"
 msgstr "Almacén"
+
+#. module: sale_order_type_ux
+#: model_terms:ir.ui.view,arch_db:sale_order_type_ux.sale_order_type_form_view
+msgid "Be careful when making modifications to this sale order type as it has"
+msgstr "Tenga cuidado al hacer modificaciones sobre este tipo de pedido de venta ya que tiene"
+
+#. module: sale_order_type_ux
+#: model_terms:ir.ui.view,arch_db:sale_order_type_ux.sale_order_type_form_view
+msgid "associated invoices"
+msgstr "facturas asociadas"
+
+#. module: sale_order_type_ux
+#: model_terms:ir.ui.view,arch_db:sale_order_type_ux.sale_order_type_form_view
+msgid "<span invisible=\"invoice_count == 0 or so_count == 0\"> and </span>"
+msgstr "<span invisible=\"invoice_count == 0 or so_count == 0\"> y </span>"
+
+#. module: sale_order_type_ux
+#: model_terms:ir.ui.view,arch_db:sale_order_type_ux.sale_order_type_form_view
+msgid "associated sale orders"
+msgstr "pedidos de venta asociados"

--- a/sale_order_type_ux/i18n/sale_order_type_ux.pot
+++ b/sale_order_type_ux/i18n/sale_order_type_ux.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-25 14:18+0000\n"
-"PO-Revision-Date: 2025-11-25 14:18+0000\n"
+"POT-Creation-Date: 2026-05-13 18:23+0000\n"
+"PO-Revision-Date: 2026-05-13 18:23+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,6 +21,11 @@ msgid "/&gt;"
 msgstr ""
 
 #. module: sale_order_type_ux
+#: model_terms:ir.ui.view,arch_db:sale_order_type_ux.sale_order_type_form_view
+msgid "<span invisible=\"invoice_count == 0 or so_count == 0\"> and </span>"
+msgstr ""
+
+#. module: sale_order_type_ux
 #: model:ir.model.fields,field_description:sale_order_type_ux.field_sale_order_type__active
 msgid "Active"
 msgstr ""
@@ -29,6 +34,11 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:sale_order_type_ux.sale_order_type_form_view
 #: model_terms:ir.ui.view,arch_db:sale_order_type_ux.sale_order_type_search_view
 msgid "Archived"
+msgstr ""
+
+#. module: sale_order_type_ux
+#: model_terms:ir.ui.view,arch_db:sale_order_type_ux.sale_order_type_form_view
+msgid "Be careful when making modifications to this sale order type as it has"
 msgstr ""
 
 #. module: sale_order_type_ux
@@ -71,6 +81,11 @@ msgid "Invoice Company"
 msgstr ""
 
 #. module: sale_order_type_ux
+#: model:ir.model.fields,field_description:sale_order_type_ux.field_sale_order_type__invoice_count
+msgid "Invoice Count"
+msgstr ""
+
+#. module: sale_order_type_ux
 #: model:ir.model.fields,field_description:sale_order_type_ux.field_sale_order_type__journal_id
 msgid "Invoice Journal"
 msgstr ""
@@ -83,6 +98,21 @@ msgstr ""
 #. module: sale_order_type_ux
 #: model_terms:ir.ui.view,arch_db:sale_order_type_ux.sale_order_type_form_view
 msgid "Notes"
+msgstr ""
+
+#. module: sale_order_type_ux
+#: model:ir.model.fields,help:sale_order_type_ux.field_sale_order_type__invoice_count
+msgid ""
+"Number of invoices created from sales orders of this type. This field is "
+"used to determine whether the modification of a sale order type is not "
+"recommended."
+msgstr ""
+
+#. module: sale_order_type_ux
+#: model:ir.model.fields,help:sale_order_type_ux.field_sale_order_type__so_count
+msgid ""
+"Number of sales orders created from this type. This field is used to "
+"determine whether the modification of a sale order type is not recommended."
 msgstr ""
 
 #. module: sale_order_type_ux
@@ -108,6 +138,11 @@ msgstr ""
 #. module: sale_order_type_ux
 #: model:ir.model.fields,help:sale_order_type_ux.field_sale_order_type__active
 msgid "Set active to false to hide the type of sale without removing it."
+msgstr ""
+
+#. module: sale_order_type_ux
+#: model:ir.model.fields,field_description:sale_order_type_ux.field_sale_order_type__so_count
+msgid "So Count"
 msgstr ""
 
 #. module: sale_order_type_ux
@@ -138,4 +173,14 @@ msgstr ""
 #. module: sale_order_type_ux
 #: model:ir.model.fields,field_description:sale_order_type_ux.field_sale_order_type__warehouse_id
 msgid "Warehouse"
+msgstr ""
+
+#. module: sale_order_type_ux
+#: model_terms:ir.ui.view,arch_db:sale_order_type_ux.sale_order_type_form_view
+msgid "associated invoices"
+msgstr ""
+
+#. module: sale_order_type_ux
+#: model_terms:ir.ui.view,arch_db:sale_order_type_ux.sale_order_type_form_view
+msgid "associated sale orders"
 msgstr ""

--- a/sale_order_type_ux/models/sale_order_type.py
+++ b/sale_order_type_ux/models/sale_order_type.py
@@ -53,6 +53,14 @@ class SaleOrderTypology(models.Model):
     journal_id = fields.Many2one(
         "account.journal", string="Invoice Journal", domain="journal_domain", check_company=False
     )
+    invoice_count = fields.Integer(
+        compute="_compute_invoice_count",
+        help="Number of invoices created from sales orders of this type. This field is used to determine whether the modification of a sale order type is not recommended.",
+    )
+    so_count = fields.Integer(
+        compute="_compute_so_count",
+        help="Number of sales orders created from this type. This field is used to determine whether the modification of a sale order type is not recommended.",
+    )
 
     @api.depends("company_id")
     def _compute_invoice_company_id(self):
@@ -71,3 +79,11 @@ class SaleOrderTypology(models.Model):
         for rec in self:
             if rec.journal_id and rec.journal_id not in rec.env["account.journal"].search(rec.journal_domain):
                 raise ValidationError("The selected 'Invoice Journal' does not belong to the selected invoice company.")
+
+    def _compute_invoice_count(self):
+        for rec in self:
+            rec.invoice_count = self.env["account.move"].search_count([("sale_type_id", "=", rec.id)])
+
+    def _compute_so_count(self):
+        for rec in self:
+            rec.so_count = self.env["sale.order"].search_count([("type_id", "=", rec.id)])

--- a/sale_order_type_ux/views/sale_order_type_views.xml
+++ b/sale_order_type_ux/views/sale_order_type_views.xml
@@ -48,6 +48,14 @@
             <group position="before">
                 <widget name="web_ribbon" title="Archived" bg_color="bg-danger" invisible="active"/>
             </group>
+            <xpath expr="//sheet" position="before">
+                <field name="invoice_count" invisible="1"/>
+                <field name="so_count" invisible="1"/>
+                <div class="alert alert-warning" role="alert" invisible="invoice_count == 0 and so_count == 0">
+                    Be careful when making modifications to this sale order type as it has
+                    <span invisible="invoice_count == 0"><field name="invoice_count" readonly="1" nolabel="1"/> associated invoices</span><span invisible="invoice_count == 0 or so_count == 0"> and </span><span invisible="so_count == 0"><field name="so_count" readonly="1" nolabel="1"/> associated sale orders</span>.
+                </div>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
When modifying a sale order type that has already been used to create invoices, it can lead to unexpected consequences on the already created invoices. For example, if the invoice journal is changed, it will not be updated on the already created invoices, which can lead to confusion for the users.