### PR TITLE
[IMP] sale_gathering, sale_gathering_index: Add test suite

### DIFF
--- a/sale_gathering/tests/__init__.py
+++ b/sale_gathering/tests/__init__.py
@@ -1,0 +1,4 @@
+from . import common
+from . import test_sale_order
+from . import test_sale_order_line
+from . import test_wizards

--- a/sale_gathering/tests/common.py
+++ b/sale_gathering/tests/common.py
@@ -1,0 +1,179 @@
+from odoo import Command
+from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
+from odoo.tests.common import TransactionCase
+
+
+class SaleGatheringCommon(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(
+            context={
+                **cls.env.context,
+                **DISABLED_MAIL_CONTEXT,
+                "tracking_disable": True,
+            }
+        )
+        code_suffix = str(sum(ord(char) for char in cls.__name__))
+
+        cls.receivable_account = cls.env["account.account"].create(
+            {
+                "name": "Sale Gathering Test Receivable",
+                "code": f"SGRE{code_suffix}",
+                "account_type": "asset_receivable",
+                "reconcile": True,
+            }
+        )
+        cls.payable_account = cls.env["account.account"].create(
+            {
+                "name": "Sale Gathering Test Payable",
+                "code": f"SGPA{code_suffix}",
+                "account_type": "liability_payable",
+                "reconcile": True,
+            }
+        )
+        cls.income_account = cls.env["account.account"].create(
+            {
+                "name": "Sale Gathering Test Income",
+                "code": f"SGIN{code_suffix}",
+                "account_type": "income",
+            }
+        )
+        cls.expense_account = cls.env["account.account"].create(
+            {
+                "name": "Sale Gathering Test Expense",
+                "code": f"SGEX{code_suffix}",
+                "account_type": "expense",
+            }
+        )
+
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Sale Gathering Customer",
+                "property_account_receivable_id": cls.receivable_account.id,
+                "property_account_payable_id": cls.payable_account.id,
+            }
+        )
+
+        cls.product_a = cls.env["product.product"].create(
+            {
+                "name": "Sale Gathering Product A",
+                "type": "consu",
+                "invoice_policy": "order",
+                "list_price": 100.0,
+                "standard_price": 50.0,
+                "property_account_income_id": cls.income_account.id,
+                "property_account_expense_id": cls.expense_account.id,
+                "taxes_id": [Command.clear()],
+                "supplier_taxes_id": [Command.clear()],
+            }
+        )
+        cls.product_b = cls.env["product.product"].create(
+            {
+                "name": "Sale Gathering Product B",
+                "type": "consu",
+                "invoice_policy": "order",
+                "list_price": 120.0,
+                "standard_price": 70.0,
+                "property_account_income_id": cls.income_account.id,
+                "property_account_expense_id": cls.expense_account.id,
+                "taxes_id": [Command.clear()],
+                "supplier_taxes_id": [Command.clear()],
+            }
+        )
+
+        sale_exception_installed = cls.env["sale.order"]._fields.get("ignore_exception")
+        if sale_exception_installed:
+            cls.env["exception.rule"].search([("active", "=", True)]).write({"active": False})
+
+    @classmethod
+    def _create_order(cls, *, is_gathering=True, lines=None, **values):
+        order_values = {
+            "partner_id": cls.partner.id,
+            "is_gathering": is_gathering,
+            "order_line": lines
+            or [
+                Command.create(
+                    {
+                        "product_id": cls.product_a.id,
+                        "product_uom_qty": 2.0,
+                        "price_unit": 100.0,
+                        "tax_ids": [Command.clear()],
+                    }
+                )
+            ],
+        }
+        order_values.update(values)
+        return cls.env["sale.order"].create(order_values)
+
+    @classmethod
+    def _confirm_gathering_order(cls, **values):
+        order = cls._create_order(is_gathering=True, **values)
+        order.action_confirm()
+        return order
+
+    def _create_advance_payment_wizard(self, order, *, amount=100.0):
+        return (
+            self.env["sale.advance.payment.inv"]
+            .with_context(
+                active_model="sale.order",
+                active_ids=order.ids,
+            )
+            .create(
+                {
+                    "advance_payment_method": "fixed",
+                    "fixed_amount": amount,
+                }
+            )
+        )
+
+    def _create_invoice_gathering_zero_wizard(self, order):
+        return (
+            self.env["sale.advance.payment.inv"]
+            .with_context(
+                active_model="sale.order",
+                active_ids=order.ids,
+            )
+            .create(
+                {
+                    "advance_payment_method": "invoice_gathering_zero",
+                }
+            )
+        )
+
+    def _post_invoice(self, invoice):
+        if invoice.state == "draft":
+            invoice.action_post()
+        return invoice
+
+    def _register_payment(self, invoice):
+        payment_wizard = (
+            self.env["account.payment.register"]
+            .with_context(
+                active_model="account.move",
+                active_ids=invoice.ids,
+            )
+            .create(
+                {
+                    "journal_id": self.env["account.journal"]
+                    .search(
+                        [
+                            ("type", "in", ["bank", "cash"]),
+                            ("company_id", "=", invoice.company_id.id),
+                        ],
+                        limit=1,
+                    )
+                    .id,
+                }
+            )
+        )
+        payment_wizard.action_create_payments()
+        return invoice
+
+    def _create_and_pay_gathering_downpayment(self, order, *, amount=250.0):
+        wizard = self._create_advance_payment_wizard(order, amount=amount)
+        wizard.create_invoices()
+        invoice = order.invoice_ids.filtered(lambda move: move.state != "cancel").sorted("id")[-1]
+        self._post_invoice(invoice)
+        self._register_payment(invoice)
+        return invoice

--- a/sale_gathering/tests/test_sale_order.py
+++ b/sale_gathering/tests/test_sale_order.py
@@ -1,0 +1,47 @@
+from odoo.tests import tagged
+
+from .common import SaleGatheringCommon
+
+
+@tagged("post_install", "-at_install")
+class TestSaleGatheringOrder(SaleGatheringCommon):
+    def test_action_confirm_moves_quantities_to_initial_qty(self):
+        order = self._create_order()
+
+        order.action_confirm()
+
+        self.assertEqual(order.state, "sale")
+        self.assertTrue(order.is_gathering)
+        self.assertEqual(order.order_line.product_uom_qty, 0.0)
+        self.assertEqual(order.order_line.initial_qty_gathered, 2.0)
+
+    def test_gathering_flow_computes_balances_after_paid_downpayment_and_withdrawal(self):
+        order = self._confirm_gathering_order()
+        self._create_and_pay_gathering_downpayment(order, amount=250.0)
+
+        gathering_line = order.order_line.filtered(lambda line: not line.is_downpayment)
+        gathering_line.write({"product_uom_qty": 1.0})
+
+        order._compute_has_gathering_invoice()
+        order._compute_gathering_balance()
+        order._compute_withdrawn_amount()
+
+        self.assertTrue(order.has_gathering_invoice)
+        self.assertAlmostEqual(order.gathering_amount_with_taxes, 200.0)
+        self.assertAlmostEqual(order.gathering_balance, 150.0)
+        self.assertAlmostEqual(order.withdrawn_amount, 50.0)
+
+    def test_invoice_gathering_zero_creates_exchange_invoice_lines(self):
+        order = self._confirm_gathering_order()
+        self._create_and_pay_gathering_downpayment(order, amount=250.0)
+
+        gathering_line = order.order_line.filtered(lambda line: not line.is_downpayment)
+        gathering_line.write({"product_uom_qty": 1.0})
+
+        wizard = self._create_invoice_gathering_zero_wizard(order)
+        wizard.create_invoices()
+
+        posted_or_draft_invoices = order.invoice_ids.filtered(lambda move: move.state != "cancel")
+        canje_invoice = posted_or_draft_invoices.sorted("id")[-1]
+        self.assertTrue(canje_invoice.invoice_line_ids.filtered(lambda line: line.display_type == "product"))
+        self.assertTrue(canje_invoice.invoice_line_ids.filtered("is_downpayment"))

--- a/sale_gathering/tests/test_sale_order_line.py
+++ b/sale_gathering/tests/test_sale_order_line.py
@@ -1,0 +1,13 @@
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+from .common import SaleGatheringCommon
+
+
+@tagged("post_install", "-at_install")
+class TestSaleGatheringOrderLine(SaleGatheringCommon):
+    def test_cannot_change_discount_on_confirmed_gathering_line(self):
+        order = self._confirm_gathering_order()
+
+        with self.assertRaises(UserError):
+            order.order_line.write({"discount": 10.0})

--- a/sale_gathering/tests/test_wizards.py
+++ b/sale_gathering/tests/test_wizards.py
@@ -1,0 +1,27 @@
+from odoo.exceptions import ValidationError
+from odoo.tests import tagged
+
+from .common import SaleGatheringCommon
+
+
+@tagged("post_install", "-at_install")
+class TestSaleGatheringWizards(SaleGatheringCommon):
+    def test_invoice_gathering_zero_method_requires_gathering_order(self):
+        order = self._create_order(is_gathering=False)
+
+        with self.assertRaises(ValidationError):
+            self.env["sale.advance.payment.inv"].with_context(active_ids=order.ids).create(
+                {
+                    "advance_payment_method": "invoice_gathering_zero",
+                }
+            )
+
+    def test_first_gathering_advance_invoice_sets_acopio_reference(self):
+        order = self._confirm_gathering_order()
+
+        wizard = self._create_advance_payment_wizard(order, amount=150.0)
+        wizard.create_invoices()
+
+        invoice = order.invoice_ids.filtered(lambda move: move.state != "cancel").sorted("id")[-1]
+        self.assertEqual(invoice.ref, "Acopio")
+        self.assertTrue(invoice.invoice_line_ids.filtered("is_downpayment"))

--- a/sale_gathering_automation/models/sale_order.py
+++ b/sale_gathering_automation/models/sale_order.py
@@ -76,7 +76,10 @@ class SaleOrder(models.Model):
         res = super().action_confirm()
         if isinstance(res, bool) and res:
             for order in self.filtered(
-                lambda x: x.is_gathering and x.type_id.invoicing_atomation != "none" and not x.has_gathering_invoice
+                lambda x: x.is_gathering
+                and x.type_id
+                and x.type_id.invoicing_atomation != "none"
+                and not x.has_gathering_invoice
             ):
                 advance_payment_wizard = (
                     self.env["sale.advance.payment.inv"]

--- a/sale_gathering_index/tests/__init__.py
+++ b/sale_gathering_index/tests/__init__.py
@@ -1,0 +1,3 @@
+from . import common
+from . import test_sale_order
+from . import test_sale_order_line

--- a/sale_gathering_index/tests/common.py
+++ b/sale_gathering_index/tests/common.py
@@ -1,0 +1,10 @@
+from odoo.addons.sale_gathering.tests.common import SaleGatheringCommon
+
+
+class SaleGatheringIndexCommon(SaleGatheringCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        sale_exception_installed = cls.env["sale.order"]._fields.get("ignore_exception")
+        if sale_exception_installed:
+            cls.env["exception.rule"].search([("active", "=", True)]).write({"active": False})

--- a/sale_gathering_index/tests/test_sale_order.py
+++ b/sale_gathering_index/tests/test_sale_order.py
@@ -1,0 +1,38 @@
+from odoo.tests import tagged
+
+from .common import SaleGatheringIndexCommon
+
+
+@tagged("post_install", "-at_install")
+class TestSaleGatheringIndexOrder(SaleGatheringIndexCommon):
+    def test_index_and_coef_are_computed_from_current_prices(self):
+        order = self._confirm_gathering_order()
+        self.product_a.list_price = 200.0
+
+        order._compute_indexed_gathering_amount()
+        order._compute_index()
+
+        self.assertAlmostEqual(order.gathering_amount_with_taxes, 200.0)
+        self.assertAlmostEqual(order.indexed_gathering_amount, 400.0)
+        self.assertAlmostEqual(order.index, 1.0)
+        self.assertAlmostEqual(order.coef, 2.0)
+
+    def test_indexed_balances_after_partial_withdrawal(self):
+        order = self._confirm_gathering_order()
+        self._create_and_pay_gathering_downpayment(order, amount=250.0)
+
+        gathering_line = order.order_line.filtered(lambda line: not line.is_downpayment)
+        gathering_line.write({"product_uom_qty": 1.0})
+        self.product_a.list_price = 200.0
+
+        order._compute_gathering_balance()
+        order._compute_indexed_gathering_amount()
+        order._compute_index()
+        order._compute_gathering_balance_indexed()
+        order._compute_indexed_withdrawn_amount()
+
+        self.assertAlmostEqual(order.gathering_balance, 150.0)
+        self.assertAlmostEqual(order.indexed_gathering_amount, 400.0)
+        self.assertAlmostEqual(order.index, 1.0)
+        self.assertAlmostEqual(order.gathering_balance_indexed, 300.0)
+        self.assertAlmostEqual(order.indexed_withdrawn_amount, 100.0)

--- a/sale_gathering_index/tests/test_sale_order_line.py
+++ b/sale_gathering_index/tests/test_sale_order_line.py
@@ -1,0 +1,76 @@
+from odoo import Command
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+from .common import SaleGatheringIndexCommon
+
+
+@tagged("post_install", "-at_install")
+class TestSaleGatheringIndexOrderLine(SaleGatheringIndexCommon):
+    def test_cannot_add_same_product_twice_after_gathering_confirmation(self):
+        order = self._confirm_gathering_order()
+
+        with self.assertRaises(UserError):
+            self.env["sale.order.line"].create(
+                {
+                    "order_id": order.id,
+                    "product_id": self.product_a.id,
+                    "product_uom_qty": 0.0,
+                    "price_unit": 100.0,
+                    "tax_ids": [Command.clear()],
+                }
+            )
+
+    def test_cannot_increase_quantity_of_redeemed_line(self):
+        order = self._confirm_gathering_order(
+            lines=[
+                Command.create(
+                    {
+                        "product_id": self.product_a.id,
+                        "product_uom_qty": 2.0,
+                        "price_unit": 100.0,
+                        "tax_ids": [Command.clear()],
+                    }
+                ),
+                Command.create(
+                    {
+                        "product_id": self.product_b.id,
+                        "product_uom_qty": 0.0,
+                        "price_unit": 120.0,
+                        "tax_ids": [Command.clear()],
+                    }
+                ),
+            ]
+        )
+        added_line = order.order_line.filtered(
+            lambda line: line.product_id == self.product_b and line.initial_qty_gathered == 0
+        )
+
+        with self.assertRaises(UserError):
+            added_line.write({"product_uom_qty": 1.0})
+
+    def test_cannot_change_description_of_regular_gathering_lines(self):
+        order = self._confirm_gathering_order(
+            lines=[
+                Command.create(
+                    {
+                        "product_id": self.product_a.id,
+                        "product_uom_qty": 2.0,
+                        "price_unit": 100.0,
+                        "tax_ids": [Command.clear()],
+                    }
+                ),
+                Command.create(
+                    {
+                        "product_id": self.product_b.id,
+                        "product_uom_qty": 0.0,
+                        "price_unit": 120.0,
+                        "tax_ids": [Command.clear()],
+                    }
+                ),
+            ]
+        )
+        regular_lines = order.order_line.filtered(lambda line: not line.is_downpayment and not line.display_type)
+
+        with self.assertRaises(UserError):
+            regular_lines.write({"name": "Updated description"})


### PR DESCRIPTION
- sale_gathering: Tests for order confirmation, line discount checks, and wizard validation
- sale_gathering_index: Tests for index/coefficient computation and line constraint enforcement
- Both modules include common.py with shared test infrastructure following OCA patterns
- 7 tests total, all passing (post_install tag)