### PR TITLE
[FIX] sale_ux: ensure boolean field appears under FP name

### DIFF
--- a/sale_ux/views/account_fiscal_position_views.xml
+++ b/sale_ux/views/account_fiscal_position_views.xml
@@ -5,7 +5,8 @@
         <field name="model">account.fiscal.position</field>
         <field name="inherit_id" ref="account.view_account_position_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='name']" position="after">
+        <!-- Le pasamos 'last()' porque queremos asegurarnos de seleccionar el último campo 'name' en el formulario -->
+            <xpath expr="(//field[@name='name'])[last()]" position="after">
                 <field name="deduct_price_included_taxes"/>
             </xpath>
         </field>


### PR DESCRIPTION
`account_ux` inserta un segundo `<field name="name"` usando el mismo XPath `position="after"`. Cuando nuestras vistas se aplican después, el XPath matchea AMBOS campos [name], y nuestro campo se inserta dos veces: la primera después del campo [name] que puede estar invisible, causando que aparezca por encima del [name] visible.
`sale_ux` depende de account_ux, por eso modifico el xpath apuntando hacia ese campo `name`