### PR TITLE
[ADD] sale_stock_picking_sections: secciones de OV (PLPs) en reporte de picking

### DIFF
--- a/sale_stock_picking_sections/__init__.py
+++ b/sale_stock_picking_sections/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_stock_picking_sections/__manifest__.py
+++ b/sale_stock_picking_sections/__manifest__.py
@@ -1,0 +1,37 @@
+##############################################################################
+#
+#    Copyright (C) 2026  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Sale Stock Picking Sections",
+    "version": "19.0.1.0.0",
+    "category": "Inventory/Inventory",
+    "summary": "Muestra las secciones de la OV (PLPs) en el reporte de operaciones de picking",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "depends": [
+        "sale_stock_ux",
+    ],
+    "data": [
+        "reports/report_picking_sections.xml",
+    ],
+    "installable": True,
+    "auto_install": True,
+    "application": False,
+}

--- a/sale_stock_picking_sections/models/__init__.py
+++ b/sale_stock_picking_sections/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_picking

--- a/sale_stock_picking_sections/models/stock_picking.py
+++ b/sale_stock_picking_sections/models/stock_picking.py
@@ -1,0 +1,56 @@
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def _get_moves_by_section(self):
+        """Agrupa los moves del picking por sección de la OV de origen (PLPs).
+
+        Retorna lista de (section_name, moves_recordset).
+        Mantiene el orden de secciones de la OV original.
+        Si el picking no viene de una OV con secciones, retorna [(False, all_moves)].
+        """
+        self.ensure_one()
+        moves = self.move_ids.filtered(
+            lambda m: m.quantity and any(not ml.is_entire_pack for ml in m.move_line_ids)
+        ).sorted(key=lambda m: (
+            m.move_line_ids[0].location_id.complete_name if m.move_line_ids else "",
+            m.move_line_ids[0].location_dest_id.complete_name if m.move_line_ids else "",
+        ))
+
+        sale_order = moves.mapped("sale_line_id.order_id")[:1]
+        if not sale_order:
+            return [(False, moves)]
+
+        has_sections = any(
+            line.display_type == "line_section" for line in sale_order.order_line
+        )
+        if not has_sections:
+            return [(False, moves)]
+
+        # Mapea cada sale.order.line a su sección precedente, en orden de la OV
+        section_by_line_id = {}
+        sections_in_ov_order = []
+        current_section = False
+        for line in sale_order.order_line.sorted("sequence"):
+            if line.display_type == "line_section":
+                current_section = line.name
+                if current_section not in sections_in_ov_order:
+                    sections_in_ov_order.append(current_section)
+            elif not line.display_type:
+                section_by_line_id[line.id] = current_section
+
+        # Inicializa grupos vacíos en orden de OV; False al final para moves sin sección
+        sections_dict = {s: self.env["stock.move"] for s in sections_in_ov_order}
+        sections_dict[False] = self.env["stock.move"]
+
+        for move in moves:
+            # sale_line_id.id devuelve False si el campo está vacío
+            section = section_by_line_id.get(move.sale_line_id.id, False)
+            sections_dict[section] |= move
+
+        result = [(s, sections_dict[s]) for s in sections_in_ov_order if sections_dict[s]]
+        if sections_dict[False]:
+            result.append((False, sections_dict[False]))
+        return result

--- a/sale_stock_picking_sections/reports/report_picking_sections.xml
+++ b/sale_stock_picking_sections/reports/report_picking_sections.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!--
+        Extiende el reporte "Picking Operations" (stock.report_picking /
+        stock_ux.report_picking_ux) para mostrar las secciones de la OV
+        (PLPs) como filas de encabezado entre los productos.
+
+        El xpath reemplaza el único <t t-foreach> hijo directo del <tbody>
+        de la tabla principal (clase o_main_table), que es el loop que
+        itera los stock.move. Lo sustituye con un loop de dos niveles:
+        sección → moves, inyectando una fila de cabecera por cada sección.
+
+        La lógica de la primera columna (origin_description vs display_name)
+        se replica aquí para mantener el comportamiento de stock_ux.
+    -->
+    <template id="report_picking_sections" inherit_id="stock.report_picking">
+        <xpath expr="//table[contains(@class,'o_main_table')]//tbody/t" position="replace">
+            <t t-foreach="o._get_moves_by_section()" t-as="section_item">
+                <t t-set="section_name" t-value="section_item[0]"/>
+                <t t-set="section_moves" t-value="section_item[1]"/>
+                <tr t-if="section_name" class="o_line_section">
+                    <td colspan="99" style="font-weight: bold; padding: 4px 8px; background-color: #f5f5f5; border-bottom: 1px solid #dee2e6;">
+                        <span t-out="section_name"/>
+                    </td>
+                </tr>
+                <t t-foreach="section_moves" t-as="move">
+                    <t t-set="move_lines_without_entire_pack" t-value="move.move_line_ids.filtered(lambda ml: not ml.is_entire_pack)"/>
+                    <t t-set="move_has_multiple_lines" t-value="len(move.move_line_ids) > 1 or any(ml.lot_id or ml.lot_name for ml in move_lines_without_entire_pack)"/>
+                    <tr>
+                        <td class="text-start">
+                            <span t-if="env['ir.config_parameter'].sudo().get_param('stock_ux.delivery_slip_use_origin', 'False') == 'True'" t-field="move.origin_description"/>
+                            <span t-else="" t-field="move.product_id.display_name"/>
+                            <br/>
+                            <span t-if="move.product_id.description_picking" t-field="move.product_id.description_picking"/>
+                        </td>
+                        <td class="o_td_quantity text-end">
+                            <span t-out="format_number(move.quantity)" class="text-nowrap"/>
+                            <span t-field="move.product_uom" groups="uom.group_uom"/>
+                            <span t-if="move.packaging_uom_id and move.packaging_uom_id != move.product_uom">
+                                (<span t-field="move.packaging_uom_qty" t-options='{"widget": "integer"}'/> <span t-field="move.packaging_uom_id.name"/>)
+                            </span>
+                        </td>
+                        <td class="text-start" t-if="from_col_exists" groups="stock.group_stock_multi_locations">
+                            <div t-if="move.move_line_ids and not move_has_multiple_lines">
+                                <span t-field="move.move_line_ids[0].location_id.display_name"/>
+                                <t t-if="move.move_line_ids[0].package_id">
+                                    <span t-field="move.move_line_ids[0].package_id"/>
+                                </t>
+                            </div>
+                        </td>
+                        <td class="text-start" t-if="to_col_exists" groups="stock.group_stock_multi_locations">
+                            <div t-if="move.move_line_ids and not move_has_multiple_lines">
+                                <span t-field="move.move_line_ids[0].location_dest_id.display_name"/>
+                                <t t-if="move.move_line_ids[0].result_package_id">
+                                    <span t-field="move.move_line_ids[0].result_package_id"/>
+                                </t>
+                            </div>
+                        </td>
+                        <td class="text-center" t-if="barcode_col_exists">
+                            <span t-if="move.product_id and move.product_id.barcode">
+                                <div t-field="move.product_id.barcode" t-options="{'widget': 'barcode', 'symbology': 'auto', 'width': 400, 'height': 100, 'quiet': 0, 'img_style': 'height:35px;'}"/>
+                            </span>
+                        </td>
+                    </tr>
+                    <!-- Detalle de líneas cuando hay lotes / múltiples ubicaciones -->
+                    <t t-if="move_has_multiple_lines" t-foreach="move_lines_without_entire_pack.sorted(key=lambda ml: (ml.location_id.complete_name, ml.location_dest_id.complete_name))" t-as="line">
+                        <tr>
+                            <td class="text-start">
+                                <span style="margin-left: 50px;" t-if="line.lot_id or line.lot_name" t-out="line.lot_id.name"/>
+                            </td>
+                            <td class="text-end">
+                                <span t-out="format_number(line.quantity)"/>
+                                <span t-field="line.product_uom_id" groups="uom.group_uom"/>
+                            </td>
+                            <td class="text-start" t-if="from_col_exists" groups="stock.group_stock_multi_locations">
+                                <span t-field="line.location_id.display_name"/>
+                                <t t-if="line.package_id">
+                                    <span t-field="line.package_id"/>
+                                </t>
+                            </td>
+                            <td class="text-start" t-if="to_col_exists" groups="stock.group_stock_multi_locations">
+                                <span t-field="line.location_dest_id.display_name"/>
+                                <t t-if="line.result_package_id">
+                                    <span t-field="line.result_package_id"/>
+                                </t>
+                            </td>
+                            <td class="text-center h6" t-if="barcode_col_exists">
+                                <span t-if="line.lot_id or line.lot_name" t-out="line.lot_id.name or line.lot_name" t-options="{'widget': 'barcode', 'humanreadable': 1, 'width': 400, 'height': 100, 'img_style': 'width:100%;height:35px;'}"/>
+                            </td>
+                        </tr>
+                    </t>
+                </t>
+            </t>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Qué hace

Agrega el módulo `sale_stock_picking_sections` que muestra las secciones
de la orden de venta (PLPs) como filas de encabezado en el reporte PDF
"Operaciones de picking" (`stock.report_picking`).

## Comportamiento

- Cuando el picking viene de una OV con secciones (`display_type='line_section'`),
  los productos aparecen agrupados bajo su PLP correspondiente, en el mismo
  orden que en la OV.
- Si el picking no tiene OV o la OV no tiene secciones, el reporte muestra
  la lista plana existente (sin cambios).
- Compatible con lotes/n° de serie y con la opción `origin_description` de `stock_ux`.

## Relacionado

Task: https://www.adhoc.inc/odoo/my-tasks/68253