### PR TITLE
[FIX] sale_timesheet_extra_hours: fix cross-company currency rate lookup

### DIFF
--- a/sale_timesheet_extra_hours/__manifest__.py
+++ b/sale_timesheet_extra_hours/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "Sales Timesheet Extra Hours",
     "summary": "",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",
     "author": "ADHOC SA",

--- a/sale_timesheet_extra_hours/models/account_analytic_line.py
+++ b/sale_timesheet_extra_hours/models/account_analytic_line.py
@@ -16,22 +16,38 @@ class AccountAnalyticLine(models.Model):
     cost = fields.Float()
 
     def _timesheet_postprocess_values(self, values):
-        """Override to trigger cost recalculation when extra_hour fields change"""
         result = super()._timesheet_postprocess_values(values)
-        # Add extra_hour and extra_hour_type to the list of fields that trigger cost recalculation
-        if any(field_name in values for field_name in ["extra_hour", "extra_hour_type"]):
-            sudo_self = self.sudo()
-            for timesheet in sudo_self:
-                cost = timesheet._hourly_cost()
-                amount = -timesheet.unit_amount * cost
-                amount_converted = timesheet.employee_id.currency_id._convert(
-                    amount, timesheet.account_id.currency_id or timesheet.currency_id, self.env.company, timesheet.date
-                )
-                result[timesheet.id].update(
-                    {
-                        "amount": amount_converted,
-                    }
-                )
+        base_fields_changed = any(f in values for f in ["unit_amount", "employee_id", "account_id"])
+        extra_hour_changed = any(f in values for f in ["extra_hour", "extra_hour_type"])
+        if not (base_fields_changed or extra_hour_changed):
+            return result
+        for timesheet in self.sudo():
+            employee = timesheet.employee_id
+            # In multi-company setups the active company (e.g. LLC/USD) may lack
+            # exchange rates for the employee's home currency (e.g. UYU). Odoo's
+            # COALESCE then falls back to rate=1 — treating UYU as USD. Use the
+            # employee's company for rate lookup when it differs from the active one.
+            rate_company = (
+                employee.company_id
+                if employee.company_id
+                and employee.company_id != self.env.company
+                and employee.currency_id != self.env.company.currency_id
+                else self.env.company
+            )
+            needs_recompute = extra_hour_changed or (
+                base_fields_changed and rate_company != self.env.company
+            )
+            if not needs_recompute:
+                continue
+            cost = timesheet._hourly_cost()
+            amount = -timesheet.unit_amount * cost
+            amount_converted = employee.currency_id._convert(
+                amount,
+                timesheet.account_id.currency_id or timesheet.currency_id,
+                rate_company,
+                timesheet.date,
+            )
+            result[timesheet.id].update({"amount": amount_converted})
         return result
 
     def _hourly_cost(self):


### PR DESCRIPTION
## Problema

En setups multi-compañía, cuando un empleado pertenece a la Empresa A (moneda UYU) y las horas se cargan desde la Empresa B (moneda USD), Odoo busca el tipo de cambio UYU en la Empresa B. Si B no tiene tasas de UYU configuradas, el `COALESCE` de `_get_rates` devuelve `1.0` por defecto — tratando 1 UYU como 1 USD. El apunte analítico queda con un costo completamente distorsionado.

## Fix

En `_timesheet_postprocess_values`, cuando la empresa del empleado difiere de la empresa activa y tiene moneda distinta, se usa la empresa del empleado para buscar el tipo de cambio (`rate_company`). Esto garantiza que la conversión use las tasas disponibles en la empresa donde el empleado está configurado.

El fix también unifica la lógica existente para `extra_hour`/`extra_hour_type` y los campos base (`unit_amount`, `employee_id`, `account_id`) en un solo loop.

Ref: helpdesk ticket #118329