### PR TITLE
[IMP] portal_sale_distributor: separate draft and sent quotations in portal

### DIFF
--- a/portal_sale_distributor/__manifest__.py
+++ b/portal_sale_distributor/__manifest__.py
@@ -40,6 +40,7 @@
         "security/portal_sale_distributor_security.xml",
         "security/ir.model.access.csv",
         "views/portal_my_account_views.xml",
+        "views/portal_templates.xml",
         "views/portal_sale_views.xml",
         "views/product_product_views.xml",
         "views/sale_report_templates.xml",

--- a/portal_sale_distributor/controllers/__init__.py
+++ b/portal_sale_distributor/controllers/__init__.py
@@ -3,5 +3,4 @@
 # directory
 ##############################################################################
 from . import portal_account
-# TODO related to thew account_debt_management module that was deprecated
-# from . import portal
+from . import portal

--- a/portal_sale_distributor/controllers/portal.py
+++ b/portal_sale_distributor/controllers/portal.py
@@ -5,6 +5,8 @@
 from datetime import datetime, timedelta
 
 from odoo import fields, http
+from odoo.addons.portal.controllers.portal import pager as portal_pager
+from odoo.addons.sale.controllers.portal import CustomerPortal
 from odoo.http import Controller, content_disposition, request
 
 
@@ -65,3 +67,104 @@ class PortalSummary(Controller):
             ("Content-Disposition", content_disposition("Factura Abiertas" + ".xls")),
         ]
         return request.make_response(xls, headers=xlshttpheaders)
+
+
+class CustomerPortalDistributor(CustomerPortal):
+    """Extend CustomerPortal to allow portal distributors to see quotations"""
+
+    def _prepare_home_portal_values(self, counters):
+        """Add quotation counter for distributors"""
+        values = super()._prepare_home_portal_values(counters)
+        partner = request.env.user.partner_id
+
+        # Agregar contador de quotations solo para portal distributors
+        if request.env.user.has_group("portal_sale_distributor.group_portal_backend_distributor"):
+            SaleOrder = request.env["sale.order"]
+            if "quotation_count" in counters:
+                values["quotation_count"] = (
+                    SaleOrder.search_count(self._prepare_quotations_domain(partner))
+                    if SaleOrder.has_access("read")
+                    else 0
+                )
+
+        return values
+
+    def _prepare_quotations_domain(self, partner):
+        """Domain for quotations (draft and sent) (only for distributors)"""
+        return [
+            ("message_partner_ids", "child_of", [partner.commercial_partner_id.id]),
+            ("state", "in", ["draft", "sent"]),
+        ]
+
+    @http.route(["/my/quotes", "/my/quotes/page/<int:page>"], type="http", auth="user", website=True)
+    def portal_my_quotes(self, **kwargs):
+        """Show quotations (draft and sent) for portal distributors"""
+        if not request.env.user.has_group("portal_sale_distributor.group_portal_backend_distributor"):
+            return request.redirect("/my")
+
+        values = self._prepare_sale_portal_rendering_values(quotation_page=True, draft_page=True, **kwargs)
+        request.session["my_quotations_history"] = values["quotations"].ids[:100]
+        return request.render("portal_sale_distributor.portal_my_quotations", values)
+
+    def _prepare_sale_portal_rendering_values(
+        self, page=1, date_begin=None, date_end=None, sortby=None, quotation_page=False, draft_page=False, **kwargs
+    ):
+        """Override to support quotations page"""
+        if draft_page and request.env.user.has_group("portal_sale_distributor.group_portal_backend_distributor"):
+            SaleOrder = request.env["sale.order"]
+            if not sortby:
+                sortby = "date"
+
+            partner = request.env.user.partner_id
+            values = self._prepare_portal_layout_values()
+
+            url = "/my/quotes"
+            domain = self._prepare_quotations_domain(partner)
+
+            searchbar_sortings = CustomerPortal._get_sale_searchbar_sortings(self)
+            sort_order = searchbar_sortings[sortby]["order"]
+
+            if date_begin and date_end:
+                domain += [("create_date", ">", date_begin), ("create_date", "<=", date_end)]
+
+            url_args = {"date_begin": date_begin, "date_end": date_end}
+            if len(searchbar_sortings) > 1:
+                url_args["sortby"] = sortby
+
+            pager_values = portal_pager(
+                url=url,
+                total=SaleOrder.search_count(domain) if SaleOrder.has_access("read") else 0,
+                page=page,
+                step=self._items_per_page,
+                url_args=url_args,
+            )
+            orders = (
+                SaleOrder.search(domain, order=sort_order, limit=self._items_per_page, offset=pager_values["offset"])
+                if SaleOrder.has_access("read")
+                else SaleOrder
+            )
+
+            values.update(
+                {
+                    "date": date_begin,
+                    "quotations": orders.sudo(),
+                    "orders": SaleOrder,
+                    "page_name": "quote",
+                    "pager": pager_values,
+                    "default_url": url,
+                }
+            )
+
+            if len(searchbar_sortings) > 1:
+                values.update(
+                    {
+                        "sortby": sortby,
+                        "searchbar_sortings": searchbar_sortings,
+                    }
+                )
+
+            return values
+
+        return super()._prepare_sale_portal_rendering_values(
+            page=page, date_begin=date_begin, date_end=date_end, sortby=sortby, quotation_page=quotation_page, **kwargs
+        )

--- a/portal_sale_distributor/views/portal_templates.xml
+++ b/portal_sale_distributor/views/portal_templates.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Add Quotations card for Portal Distributors -->
+    <template id="portal_my_home_quotations" name="Portal My Home : Quotations" inherit_id="portal.portal_my_home" priority="21">
+        <div id="portal_client_category" position="inside">
+            <t t-if="request.env.user.has_group('portal_sale_distributor.group_portal_backend_distributor')">
+                <t t-call="portal.portal_docs_entry">
+                    <t t-set="icon" t-value="'/sale/static/src/img/bag.svg'"/>
+                    <t t-set="title">Quotations</t>
+                    <t t-set="url" t-value="'/my/quotes'"/>
+                    <t t-set="text">View and edit your quotations</t>
+                    <t t-set="placeholder_count" t-value="'quotation_count'"/>
+                </t>
+            </t>
+        </div>
+    </template>
+
+    <!-- Template for Quotations List Page -->
+    <template id="portal_my_quotations" name="My Quotations">
+        <t t-call="portal.portal_layout">
+            <t t-set="breadcrumbs_searchbar" t-value="True"/>
+
+            <t t-call="portal.portal_searchbar">
+                <t t-set="title">Quotations</t>
+            </t>
+            <div t-if="not quotations" class="alert alert-info" role="alert">
+                There are currently no quotations for your account.
+            </div>
+            <t t-if="quotations" t-call="portal.portal_table">
+                <thead>
+                    <tr class="active">
+                        <th>Quotation #</th>
+                        <th class="text-end">Quotation Date</th>
+                        <th class="text-end">Valid Until</th>
+                        <th class="text-center">Status</th>
+                        <th class="text-end">Total</th>
+                    </tr>
+                </thead>
+                <t t-foreach="quotations" t-as="quotation">
+                    <tr>
+                        <td><a t-att-href="quotation.get_portal_url()"><t t-out="quotation.name"/></a></td>
+                        <td class="text-end"><span t-field="quotation.date_order"/></td>
+                        <td class="text-end"><span t-field="quotation.validity_date"/></td>
+                        <td class="text-center">
+                            <span t-if="quotation.state == 'draft'" class="badge rounded-pill text-bg-secondary">
+                                <i class="fa fa-fw fa-pencil"/> Draft
+                            </span>
+                            <span t-if="quotation.state == 'sent'" class="badge rounded-pill text-bg-info">
+                                <i class="fa fa-fw fa-paper-plane"/> Sent
+                            </span>
+                        </td>
+                        <td class="text-end">
+                            <span t-field="quotation.amount_total"/>
+                        </td>
+                    </tr>
+                </t>
+            </t>
+        </t>
+    </template>
+
+    <!-- Add breadcrumb for quotations -->
+    <template id="portal_my_home_menu_sale" name="Portal layout : sales menu entry" inherit_id="portal.portal_breadcrumbs" priority="21">
+        <xpath expr="//ol[hasclass('o_portal_submenu')]" position="inside">
+            <li t-if="page_name == 'quote'" class="breadcrumb-item active">
+                <t>Quotations</t>
+            </li>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
Improve portal UX by separating draft and sent quotations for distributors

Previously, portal distributors could not see draft quotations in the portal,
and when they were made visible, they appeared mixed with sent quotations in
the "Quotations to Review" card, which was confusing.

This change introduces:
- New "Draft Quotations" card in /my/home showing only draft quotations
- "Quotations to Review" card now shows only sent quotations (state='sent')
- New route /my/draft_quotes to list and manage draft quotations
- Better UX: clear separation between quotations being created vs. requiring review

Portal users (non-distributors) are not affected and continue seeing only sent quotations.