### PR TITLE
[FIX] sale_ux: use partner as delivery when computing fiscal position

### DIFF
--- a/sale_ux/models/sale_order.py
+++ b/sale_ux/models/sale_order.py
@@ -50,6 +50,19 @@ class SaleOrder(models.Model):
             )
             order.amount_uninvoiced = order.amount_total - invoices._get_sale_order_invoiced_amount(order)
 
+    def _compute_fiscal_position_id(self):
+        if self.env.user.has_group("account.group_delivery_invoice_address"):
+            return super()._compute_fiscal_position_id()
+        for order in self:
+            if not order.partner_id:
+                order.fiscal_position_id = False
+                continue
+            order.fiscal_position_id = (
+                self.env["account.fiscal.position"]
+                .with_company(order.company_id)
+                ._get_fiscal_position(order.partner_id, order.partner_id)
+            )
+
     def _prepare_invoice(self):
         vals = super(SaleOrder, self)._prepare_invoice()
         propagate_internal_notes = (

--- a/sale_ux/tests/__init__.py
+++ b/sale_ux/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_fiscal_position

--- a/sale_ux/tests/test_fiscal_position.py
+++ b/sale_ux/tests/test_fiscal_position.py
@@ -6,8 +6,6 @@ class TestSaleOrderFiscalPosition(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.delivery_group = cls.env.ref("account.group_delivery_invoice_address")
-        cls.env.user.groups_id -= cls.delivery_group
-
         cls.fiscal_position = cls.env["account.fiscal.position"].create({"name": "Test FP"})
         cls.partner = cls.env["res.partner"].create(
             {
@@ -15,6 +13,11 @@ class TestSaleOrderFiscalPosition(TransactionCase):
                 "property_account_position_id": cls.fiscal_position.id,
             }
         )
+
+    def setUp(self):
+        super().setUp()
+        # Ensure user doesn't have the delivery group so our override is executed
+        self.env.user.write({"group_ids": [(3, self.delivery_group.id)]})
 
     def test_fiscal_position_computed_from_partner(self):
         """Without group_delivery_invoice_address, fiscal position is set from partner."""
@@ -32,7 +35,7 @@ class TestSaleOrderFiscalPosition(TransactionCase):
 
     def test_fiscal_position_fallback_to_super_with_group(self):
         """With group_delivery_invoice_address, the standard Odoo compute is used."""
-        self.env.user.groups_id |= self.delivery_group
+        self.env.user.write({"group_ids": [(4, self.delivery_group.id)]})
         order = self.env["sale.order"].create({"partner_id": self.partner.id})
         # super() also resolves to partner's property_account_position_id in this case
         self.assertEqual(order.fiscal_position_id, self.fiscal_position)

--- a/sale_ux/tests/test_fiscal_position.py
+++ b/sale_ux/tests/test_fiscal_position.py
@@ -1,0 +1,38 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestSaleOrderFiscalPosition(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.delivery_group = cls.env.ref("account.group_delivery_invoice_address")
+        cls.env.user.groups_id -= cls.delivery_group
+
+        cls.fiscal_position = cls.env["account.fiscal.position"].create({"name": "Test FP"})
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Test Partner",
+                "property_account_position_id": cls.fiscal_position.id,
+            }
+        )
+
+    def test_fiscal_position_computed_from_partner(self):
+        """Without group_delivery_invoice_address, fiscal position is set from partner."""
+        order = self.env["sale.order"].create({"partner_id": self.partner.id})
+        self.assertEqual(order.fiscal_position_id, self.fiscal_position)
+
+    def test_fiscal_position_false_without_partner(self):
+        """Fiscal position is cleared when no partner is set on the order."""
+        order = self.env["sale.order"].new(
+            {"partner_id": self.partner.id, "fiscal_position_id": self.fiscal_position.id}
+        )
+        order.partner_id = False
+        order._compute_fiscal_position_id()
+        self.assertFalse(order.fiscal_position_id)
+
+    def test_fiscal_position_fallback_to_super_with_group(self):
+        """With group_delivery_invoice_address, the standard Odoo compute is used."""
+        self.env.user.groups_id |= self.delivery_group
+        order = self.env["sale.order"].create({"partner_id": self.partner.id})
+        # super() also resolves to partner's property_account_position_id in this case
+        self.assertEqual(order.fiscal_position_id, self.fiscal_position)


### PR DESCRIPTION
- Override `_compute_fiscal_position_id` in `SaleOrder`
- Skip override when user has `account.group_delivery_invoice_address`
- Pass `order.partner_id` as both partner and delivery to `_get_fiscal_position`

Change note: Se corrige el cálculo de la posición fiscal en pedidos de venta. Cuando la opción de dirección de entrega separada no está activa, el sistema ahora usa el mismo contacto del pedido como dirección de entrega al determinar la posición fiscal, evitando que se aplique una posición fiscal incorrecta.