### PR TITLE
[FIX] sale_order_type_automation: usar savepoint en lugar de rollback…

### DIFF
--- a/sale_gathering_automation/models/sale_order.py
+++ b/sale_gathering_automation/models/sale_order.py
@@ -90,7 +90,7 @@ class SaleOrder(models.Model):
                     )
                 )
                 advance_payment_wizard._check_amount_is_positive()
-                invoices = advance_payment_wizard._create_invoices(order)
+                invoices = advance_payment_wizard.with_context(first_gathering_invoice=True)._create_invoices(order)
                 if invoices and order.type_id.invoicing_atomation == "validate_invoice":
                     try:
                         if order.type_id.invoice_validate_domain:
@@ -102,7 +102,7 @@ class SaleOrder(models.Model):
                                     "relativedelta": safe_eval_dateutil.relativedelta.relativedelta,
                                 },
                             )
-                            invoices_to_validate = invoices.filtered_domain(domain)
+                            invoices_to_validate = invoices - invoices.filtered_domain(domain)
                         else:
                             invoices_to_validate = invoices
                         invoices_to_validate.sudo().action_post()

--- a/sale_gathering_automation/tests/__init__.py
+++ b/sale_gathering_automation/tests/__init__.py
@@ -1,0 +1,6 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+
+from . import test_gathering_invoice_validate_domain

--- a/sale_gathering_automation/tests/test_gathering_invoice_validate_domain.py
+++ b/sale_gathering_automation/tests/test_gathering_invoice_validate_domain.py
@@ -1,0 +1,58 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+import odoo.tests.common as common
+
+
+class TestGatheringInvoiceValidateDomain(common.TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.partner = self.env["res.partner"].create({"name": "Test Gathering Partner"})
+        self.product = self.env.ref("product.product_product_4")
+        self.gathering_validate_type = self.env["sale.order.type"].create(
+            {
+                "name": "Test Gathering Validate Invoice Domain",
+                "invoicing_atomation": "validate_invoice",
+                "invoice_validate_domain": "[('move_type', '=', 'out_invoice')]",
+            }
+        )
+        sale_exception_installed = self.env["sale.order"]._fields.get("ignore_exception")
+        if sale_exception_installed:
+            self.env["exception.rule"].search([("active", "=", True)]).write({"active": False})
+        if "loyalty.program" in self.env:
+            self.env["loyalty.program"].search([("active", "=", True)]).write({"active": False})
+
+    def test_invoice_validate_domain_match_stays_draft(self):
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "type_id": self.gathering_validate_type.id,
+                "is_gathering": True,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_uom_qty": 5.0,
+                            "price_unit": 100.0,
+                        },
+                    )
+                ],
+            }
+        )
+        order.action_confirm()
+
+        self.assertTrue(
+            order.invoice_ids,
+            "Gathering invoice must be created on confirmation",
+        )
+        for invoice in order.invoice_ids:
+            self.assertEqual(
+                invoice.state,
+                "draft",
+                "Invoice %s (move_type=%r) must stay in draft because it matches "
+                "invoice_validate_domain (match -> stays draft), but state is '%s'"
+                % (invoice.id, invoice.move_type, invoice.state),
+            )

--- a/sale_order_type_automation/models/sale_order.py
+++ b/sale_order_type_automation/models/sale_order.py
@@ -26,15 +26,16 @@ class SaleOrder(models.Model):
             # we take into account if there are any transaction finish from the e-commerce
             #  and not continue with the automation in this case
             # Check sale order exclusion domain: create invoice but skip validation
+            eval_ctx = {
+                "datetime": safe_eval_datetime,
+                "context_today": lambda: fields.Date.context_today(rec),
+                "relativedelta": safe_eval_dateutil.relativedelta.relativedelta,
+            }
             skip_validation = False
             if rec.type_id.sale_order_filter_domain:
                 so_domain = safe_eval(
                     rec.type_id.sale_order_filter_domain,
-                    {
-                        "datetime": safe_eval_datetime,
-                        "context_today": lambda: fields.Date.context_today(rec),
-                        "relativedelta": safe_eval_dateutil.relativedelta.relativedelta,
-                    },
+                    eval_ctx,
                 )
                 if so_domain and rec.filtered_domain(so_domain):
                     skip_validation = True
@@ -62,25 +63,16 @@ class SaleOrder(models.Model):
                 if rec.type_id.invoice_validate_domain:
                     domain = safe_eval(
                         rec.type_id.invoice_validate_domain,
-                        {
-                            "datetime": safe_eval_datetime,
-                            "context_today": lambda: fields.Date.context_today(rec),
-                            "relativedelta": safe_eval_dateutil.relativedelta.relativedelta,
-                        },
+                        eval_ctx,
                     )
                     invoices_to_validate = (invoices - invoices.filtered_domain(domain)) if domain else invoices
                 else:
                     invoices_to_validate = invoices
+                if not invoices_to_validate:
+                    continue
                 try:
                     with rec.env.cr.savepoint():
                         invoices_to_validate.sudo().action_post()
-                        for invoice in invoices_to_validate:  # to avoid "expected singleton" error
-                            if (
-                                invoice.name
-                                and not invoice.line_ids.mapped("move_name")
-                                and invoice.name not in invoice.line_ids.mapped("move_name")
-                            ):
-                                invoice.env.add_to_compute(invoice.line_ids._fields["move_name"], invoice.line_ids)
                 except Exception as error:
                     message = _(
                         "We couldn't validate the automatically created "

--- a/sale_order_type_automation/models/sale_order.py
+++ b/sale_order_type_automation/models/sale_order.py
@@ -59,31 +59,29 @@ class SaleOrder(models.Model):
             ):
                 if rec.env.context.get("commit_invoice_automation"):
                     rec.env.cr.commit()
+                if rec.type_id.invoice_validate_domain:
+                    domain = safe_eval(
+                        rec.type_id.invoice_validate_domain,
+                        {
+                            "datetime": safe_eval_datetime,
+                            "context_today": lambda: fields.Date.context_today(rec),
+                            "relativedelta": safe_eval_dateutil.relativedelta.relativedelta,
+                        },
+                    )
+                    invoices_to_validate = (invoices - invoices.filtered_domain(domain)) if domain else invoices
+                else:
+                    invoices_to_validate = invoices
                 try:
-                    if rec.type_id.invoice_validate_domain:
-                        domain = safe_eval(
-                            rec.type_id.invoice_validate_domain,
-                            {
-                                "datetime": safe_eval_datetime,
-                                "context_today": lambda: fields.Date.context_today(rec),
-                                "relativedelta": safe_eval_dateutil.relativedelta.relativedelta,
-                            },
-                        )
-                        invoices_to_validate = (invoices - invoices.filtered_domain(domain)) if domain else invoices
-                    else:
-                        invoices_to_validate = invoices
-                    invoices_to_validate.sudo().action_post()
-                    for invoice in invoices_to_validate:  # to avoid "expected singleton" error
-                        if (
-                            invoice.name
-                            and not invoice.line_ids.mapped("move_name")
-                            and invoice.name not in invoice.line_ids.mapped("move_name")
-                        ):
-                            invoice.env.add_to_compute(invoice.line_ids._fields["move_name"], invoice.line_ids)
+                    with rec.env.cr.savepoint():
+                        invoices_to_validate.sudo().action_post()
+                        for invoice in invoices_to_validate:  # to avoid "expected singleton" error
+                            if (
+                                invoice.name
+                                and not invoice.line_ids.mapped("move_name")
+                                and invoice.name not in invoice.line_ids.mapped("move_name")
+                            ):
+                                invoice.env.add_to_compute(invoice.line_ids._fields["move_name"], invoice.line_ids)
                 except Exception as error:
-                    rec.env.cr.rollback()
-                    if not rec.env.context.get("commit_invoice_automation"):
-                        raise error
                     message = _(
                         "We couldn't validate the automatically created "
                         "invoices (ids %s), you will need to validate them"

--- a/sale_order_type_automation/tests/__init__.py
+++ b/sale_order_type_automation/tests/__init__.py
@@ -4,3 +4,4 @@
 ##############################################################################
 
 from . import test_sale_order_type_automation
+from . import test_invoice_automation_error

--- a/sale_order_type_automation/tests/test_invoice_automation_error.py
+++ b/sale_order_type_automation/tests/test_invoice_automation_error.py
@@ -1,0 +1,74 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from unittest.mock import patch
+
+from odoo.addons.sale.tests.common import TestSaleCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestInvoiceAutomationError(TestSaleCommon):
+    @classmethod
+    def setup_independent_user(cls):
+        # Keep superuser context for setup in deployments with stricter product ACLs.
+        return None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.validate_invoice_type = cls.env["sale.order.type"].create(
+            {
+                "name": "Test Validate Invoice Automation",
+                "invoicing_atomation": "validate_invoice",
+            }
+        )
+        sale_exception_installed = cls.env["sale.order"]._fields.get("ignore_exception")
+        if sale_exception_installed:
+            cls.env["exception.rule"].search([("active", "=", True)]).write({"active": False})
+
+    def _create_so(self):
+        product = self.company_data["product_service_order"]
+        return self.env["sale.order"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "type_id": self.validate_invoice_type.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "product_uom_qty": 1.0,
+                            "price_unit": 100.0,
+                        },
+                    )
+                ],
+            }
+        )
+
+    def test_arca_timeout_keeps_invoice_and_logs_error(self):
+        """Al fallar action_post (ej. timeout ARCA), la factura queda en draft y
+        se registra el error en el chatter de la factura y de la orden de venta."""
+        so = self._create_so()
+        AccountMove = self.env["account.move"]
+        with patch.object(
+            type(AccountMove),
+            "action_post",
+            side_effect=Exception("ARCA timeout"),
+        ):
+            so.action_confirm()
+
+        self.assertEqual(len(so.invoice_ids), 1, "La factura debe haberse creado")
+        invoice = so.invoice_ids
+        self.assertTrue(invoice.exists(), "La factura no debe haberse borrado por el savepoint")
+        self.assertEqual(invoice.state, "draft", "La factura debe quedar en draft si action_post falla")
+        self.assertTrue(
+            any("ARCA timeout" in (m.body or "") for m in invoice.message_ids),
+            "Se esperaba mensaje de error en el chatter de la factura",
+        )
+        self.assertTrue(
+            any("ARCA timeout" in (m.body or "") for m in so.message_ids),
+            "Se esperaba mensaje de error en el chatter de la orden de venta",
+        )


### PR DESCRIPTION
… al fallar la validación automática

En lugar de hacer un rollback completo cuando falla action_post() durante la automatización de facturación, se usa un savepoint para que solo se reviertan los cambios de la validación pero la factura quede creada. El mensaje de error se registra siempre en la factura y en la orden de venta.