### PR TITLE
[FIX] sale_ux: move Enterprise-only deferred fields to a glue module (CE ParseError)

### DIFF
--- a/sale_ux/views/sale_order_line_views.xml
+++ b/sale_ux/views/sale_order_line_views.xml
@@ -40,8 +40,6 @@
                                 <field name="journal_id" optional="hide"/>
                                 <field name="ref" optional="hide"/>
                                 <field name="product_id" optional="hide"/>
-                                <field name="deferred_start_date" string="Start Date" optional="hide"/>
-                                <field name="deferred_end_date" string="End Date" optional="hide"/>
                                 <field name="tax_ids" widget="many2many_tags" optional="hide"/>
                                 <field name="tax_tag_ids" string="Tax Grids" widget="many2many_tags" optional="hide"/>
                                 <field name="discount_date" optional="hide"/>

--- a/sale_ux_accountant/__manifest__.py
+++ b/sale_ux_accountant/__manifest__.py
@@ -1,0 +1,36 @@
+##############################################################################
+#
+#    Copyright (C) 2015  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Sale UX Accountant",
+    "version": "19.0.1.0.0",
+    "category": "Sales",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "depends": [
+        "sale_ux",
+        "account_accountant",
+    ],
+    "data": [
+        "views/sale_order_line_views.xml",
+    ],
+    "installable": True,
+    "auto_install": True,
+}

--- a/sale_ux_accountant/readme/CONTRIBUTORS.rst
+++ b/sale_ux_accountant/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Juan José Scarafía <jjs@adhoc.com.ar>

--- a/sale_ux_accountant/readme/DESCRIPTION.rst
+++ b/sale_ux_accountant/readme/DESCRIPTION.rst
@@ -1,0 +1,10 @@
+Glue module between ``sale_ux`` and ``account_accountant`` (Odoo Enterprise).
+
+It adds the deferred revenue/expense columns (``deferred_start_date`` and
+``deferred_end_date``) to the *Invoice Lines* page of the sale order line form.
+
+These fields are defined by the Enterprise ``account_accountant`` module, so
+they cannot live directly in ``sale_ux`` (it would break the view parsing on
+Community installations). This module is ``auto_install``, so the columns show
+up automatically whenever both ``sale_ux`` and ``account_accountant`` are
+installed, and never get in the way on Community-only databases.

--- a/sale_ux_accountant/views/sale_order_line_views.xml
+++ b/sale_ux_accountant/views/sale_order_line_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="sale_order_line_ux_form" model="ir.ui.view">
+        <field name="name">sale.order.line.usability.form.accountant</field>
+        <field name="model">sale.order.line</field>
+        <field name="inherit_id" ref="sale_ux.sale_order_line_ux_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='invoice_lines']/list/field[@name='product_id']" position="after">
+                <field name="deferred_start_date" string="Start Date" optional="hide"/>
+                <field name="deferred_end_date" string="End Date" optional="hide"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
### Problem

`db2800a7` ([IMP] sale_ux: add fields in Invoice Lines page) added two
columns to the *Invoice Lines* list of `sale_order_line_ux_form`:

```xml
<field name="deferred_start_date" string="Start Date" optional="hide"/>
<field name="deferred_end_date" string="End Date" optional="hide"/>
```

Both `deferred_start_date` and `deferred_end_date` are defined by
**`account_accountant`** (Odoo Enterprise). On a Community database the
fields don't exist on `account.move.line`, so loading the `sale_ux` view
raises a `ParseError`. Because it happens at view load, it blocks
installing or updating **any** module on the database, not just `sale_ux`.

### Fix

Move both columns out of `sale_ux` into a new `auto_install` glue module
**`sale_ux_accountant`** (`depends: sale_ux + account_accountant`), adding
them back through an inherited view. This follows the convention already used
across ADHOC repos for Enterprise bridges (`account_accountant_ux`,
`l10n_ar_edi_ux`) and for `auto_install` glue modules in this repo
(`crm_sale_ux`, `sale_timesheet_ux`).

Result:

- **Community**: `sale_ux` loads cleanly, no deferred columns, no ParseError.
- **Enterprise**: `sale_ux_accountant` auto-installs alongside
  `account_accountant`, so the columns appear exactly as before.
- **CE → EE later**: since the glue module is `auto_install`, installing
  `account_accountant` afterwards pulls it in automatically.

### Notes

- `sale_ux` minor version bumped `19.0.1.12.0` → `19.0.1.13.0`.
- No behaviour change for Enterprise users; field strings / order preserved
  (placed right after `product_id`, as in the original commit).
