### PR TITLE
[FIX] sale_exception_price_security: skip section/note lines in discount check

### DIFF
--- a/sale_exception_price_security/models/sale_order_line.py
+++ b/sale_exception_price_security/models/sale_order_line.py
@@ -15,7 +15,11 @@ class SaleOrderLine(models.Model):
     def check_discount_ok(self):
         self.ensure_one()
         # disable constrant
-        if self.env.user.has_group("price_security.group_only_view") and not self.product_can_modify_prices:
+        if (
+            not self.display_type
+            and self.env.user.has_group("price_security.group_only_view")
+            and not self.product_can_modify_prices
+        ):
             # if something, then we have an error, not ok
             if self.env.user.check_discount(
                 self.discount, self.order_id.pricelist_id.id, so_line=self, do_not_raise=True


### PR DESCRIPTION
## Summary

- Las líneas de sección y nota (`display_type != False`) disparaban incorrectamente la excepción "Discount Restriction" cuando se aplicaba un descuento masivo via el wizard y luego se corregían manualmente las líneas de producto.
- Se agrega `not self.display_type` como primera condición del `if` en `check_discount_ok` para que estas líneas queden excluidas de la validación de descuento.

## Test plan

- [ ] Crear una OV con líneas de sección, nota y producto
- [ ] Aplicar descuento masivo via el botón "Descuento" → "En todas las líneas del pedido"
- [ ] Corregir manualmente el descuento en las líneas de producto (dentro del rango permitido)
- [ ] Confirmar / intentar imprimir: **no debe aparecer la excepción "Discount Restriction"**
- [ ] Verificar que la excepción sí se dispara cuando una línea de *producto* tiene descuento fuera del rango

closes #119115

🤖 Generated with [Claude Code](https://claude.com/claude-code)