### PR TITLE
[FIX] sale_exception_price_security: skip section/note lines in discount check

### DIFF
--- a/sale_exception_price_security/models/sale_order_line.py
+++ b/sale_exception_price_security/models/sale_order_line.py
@@ -15,7 +15,11 @@ class SaleOrderLine(models.Model):
     def check_discount_ok(self):
         self.ensure_one()
         # disable constrant
-        if self.env.user.has_group("price_security.group_only_view") and not self.product_can_modify_prices:
+        if (
+            not self.display_type
+            and self.env.user.has_group("price_security.group_only_view")
+            and not self.product_can_modify_prices
+        ):
             # if something, then we have an error, not ok
             if self.env.user.check_discount(
                 self.discount, self.order_id.pricelist_id.id, so_line=self, do_not_raise=True


### PR DESCRIPTION
## Changes

- [FIX] sale_exception_price_security: skip section/note lines in discount check

## Related

> 🎫 **Helpdesk ticket** #119115

Task: #119115
Branch: `18.0-h-119115-gal`
