### PR TITLE
[FIX] sale_order_type_invoice_policy: restrict prepaid block to outgoing pickings

### DIFF
--- a/sale_order_type_invoice_policy/models/stock_move.py
+++ b/sale_order_type_invoice_policy/models/stock_move.py
@@ -13,7 +13,9 @@ class StockMove(models.Model):
         For the cron call check if the moves needs to be reserved or not depends of the policy in the sale order type.
         """
         prepaid_unpaid = self.sudo().filtered(
-            lambda x: x.picking_id.sale_id.type_id.invoice_policy == "prepaid" and not x.picking_id._check_sale_paid()
+            lambda x: x.picking_id.picking_type_id.code == "outgoing"
+            and x.picking_id.sale_id.type_id.invoice_policy == "prepaid"
+            and not x.picking_id._check_sale_paid()
         )
         if prepaid_unpaid:
             self -= prepaid_unpaid

--- a/sale_order_type_invoice_policy/models/stock_picking.py
+++ b/sale_order_type_invoice_policy/models/stock_picking.py
@@ -19,7 +19,8 @@ class StockPicking(models.Model):
         if any(
             self.sudo().filtered(
                 lambda x: (
-                    x.sale_id.type_id.invoice_policy in ["prepaid", "prepaid_block_delivery"]
+                    x.picking_type_id.code == "outgoing"
+                    and x.sale_id.type_id.invoice_policy in ["prepaid", "prepaid_block_delivery"]
                     and not x._check_sale_paid()
                 )
             )
@@ -34,7 +35,9 @@ class StockPicking(models.Model):
             "be invoiced and paid before you can reserve qty to this picking"
         )
         prepaid_unpaid = self.sudo().filtered(
-            lambda x: x.sale_id.type_id.invoice_policy == "prepaid" and not x._check_sale_paid()
+            lambda x: x.picking_type_id.code == "outgoing"
+            and x.sale_id.type_id.invoice_policy == "prepaid"
+            and not x._check_sale_paid()
         )
         if prepaid_unpaid and self._context.get("prepaid_raise"):
             raise UserError(_(msg))


### PR DESCRIPTION
> 🎫 **Helpdesk ticket** #119806

## Changes

- [FIX] sale_order_type_invoice_policy: restrict prepaid block to outgoing pickings

## Related

Task: #119806
Branch: `18.0-h-119806-gal`