### PR TITLE
[FIX] sale_ux: hide prices in grouped section summary when collapse_p…

### DIFF
--- a/sale_ux/views/sale_reports.xml
+++ b/sale_ux/views/sale_reports.xml
@@ -18,5 +18,15 @@
                      alt="Product image"/>
             </td>
         </td>
+        <!-- Empty image-column cell so non-product rows keep the grid aligned -->
+        <td name="td_section_name" position="before">
+            <td t-if="show_images" name="td_section_image" t-attf-style="width: {{column_width}}px;"/>
+        </td>
+        <td name="td_combo_name" position="before">
+            <td t-if="show_images" name="td_combo_image" t-attf-style="width: {{column_width}}px;"/>
+        </td>
+        <td name="td_section_group_name" position="before">
+            <td t-if="show_images" name="td_section_group_image" t-attf-style="width: {{column_width}}px;"/>
+        </td>
     </template>
 </odoo>


### PR DESCRIPTION
…rices is active

When a section has both collapse_composition=True and collapse_prices=True, the grouped summary row (t-else branch) was still showing prices because show_section_total is unconditionally True for section lines (is_section=True), ignoring collapse_prices entirely.

Add XPath overrides on td_section_group_quantity, td_section_group_priceunit and td_section_group_total spans to guard them with `not collapse_prices`.
