### PR TITLE
[FIX] sale_order_type_ux: preserve per-line taxes when posting multic…

### DIFF
--- a/sale_order_type_ux/models/account_move.py
+++ b/sale_order_type_ux/models/account_move.py
@@ -52,9 +52,12 @@ class AccountMove(models.Model):
 
                 if so_dpl.company_id != rec.company_id:
                     fp_tax_groups = self.env["account.tax.group"]
+                    # Cada línea de anticipo tiene su propia alícuota; filtramos la
+                    # invoice line vinculada a este so_dpl para no pisar todos los
+                    # impuestos con los de la última línea (clave constante en el dict).
+                    matching_lines = rec.invoice_line_ids.filtered(lambda l: so_dpl in l.sale_line_ids)
                     original_taxes = {
-                        so_dpl.id: line.tax_ids.filtered(lambda x: x.tax_group_id not in fp_tax_groups).ids[:]
-                        for line in rec.invoice_line_ids
+                        so_dpl.id: matching_lines.tax_ids.filtered(lambda x: x.tax_group_id not in fp_tax_groups).ids[:]
                     }
                     journal = rec.sale_type_id.journal_id or (
                         self.env["account.move"]


### PR DESCRIPTION
…ompany down payment invoice

The dict comprehension in action_post() used so_dpl.id as a constant key while iterating over all invoice_line_ids, collapsing every entry to the taxes of the last invoice line. On a sale order with two different VAT rates (e.g. 21% and 10.5%), both down payment sale.order.lines ended up with the same rate (21%), preventing the correct generation of the final invoice.

Fix: filter only the invoice line linked to each specific down payment sale line via sale_line_ids before building original_taxes, so each line is mapped to its own correct tax.
