### PR TITLE
[MIG] sale_exception_ux: migrate exception rules from removed sale_warn fields (v18->v19)

### DIFF
--- a/sale_exception_ux/__manifest__.py
+++ b/sale_exception_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Sale Exception UX",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "category": "Sale",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/sale_exception_ux/migrations/19.0.1.0.1/post-migrate.py
+++ b/sale_exception_ux/migrations/19.0.1.0.1/post-migrate.py
@@ -1,0 +1,47 @@
+# Copyright 2024 Adhoc SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import logging
+import re
+
+_logger = logging.getLogger(__name__)
+
+# Rewrites exception.rule.code that still references fields removed in v19:
+#   sale_warn (res.partner)      -> sale_warn_msg
+#   sale_line_warn (product.*)   -> sale_line_warn_msg
+#
+# Needed for databases migrated from v18: sale_exception ships these rules
+# inside <odoo noupdate="1">, so Odoo never rewrites them on upgrade.
+_PATTERN = re.compile(
+    r"""(?P<obj>\w+(?:\.\w+)*)\.(?P<field>sale_warn|sale_line_warn)\s*"""
+    r"""(?:==\s*['"](?:warning|block)['"]|in\s*\([^)]*\))""",
+)
+
+
+def _rewrite(match):
+    return "bool(%s.%s_msg)" % (match.group("obj"), match.group("field"))
+
+
+def migrate(cr, version):
+    cr.execute(
+        """
+        SELECT id, code FROM exception_rule
+        WHERE code ~ '(^|[^_])sale_(line_)?warn([^_a-zA-Z]|$)'
+        """
+    )
+    for rule_id, code in cr.fetchall():
+        if not code:
+            continue
+        new_code, n = _PATTERN.subn(_rewrite, code)
+        if n and new_code != code:
+            cr.execute(
+                "UPDATE exception_rule SET code = %s WHERE id = %s",
+                (new_code, rule_id),
+            )
+            _logger.info("sale_exception_ux: exception.rule %s migrated to *_warn_msg", rule_id)
+        elif "_msg" not in code:
+            _logger.warning(
+                "sale_exception_ux: exception.rule %s references sale[_line]_warn "
+                "but did not match known pattern; review manually: %s",
+                rule_id,
+                code,
+            )


### PR DESCRIPTION
## Summary

In v19, `sale_line_warn` (product) and `sale_warn` (partner) selection fields were removed from Odoo core. Only the `_msg` variants remain (`sale_line_warn_msg`, `sale_warn_msg`).

The OCA module `sale_exception` ships two rules inside `<odoo noupdate="1">`, so their `code` field is never rewritten on upgrade. Databases migrated from v18 keep the old expressions and raise `AttributeError` when confirming a sale order.

This migration is placed in `sale_exception_ux` (which depends on `sale_exception`) to fix the issue within the Adhoc release cycle, without blocking on an OCA upstream PR.

## Changes

- **New**: `sale_exception_ux/migrations/19.0.1.0.1/post-migrate.py` — rewrites via SQL + regex any `exception.rule.code` still referencing the removed fields. Covers both affected rules (`exception_partner_sale_warning`, `exception_product_sale_warning`). Idempotent.
- **Bump**: `sale_exception_ux/__manifest__.py` `19.0.1.0.0` → `19.0.1.0.1` to trigger the migration on existing v19 databases that upgraded from v18.

## Test plan

- [ ] v18 DB with both rules active and old `code` → upgrade to v19 with `sale_exception_ux` at `19.0.1.0.1` → both rules use `bool(...sale_*_warn_msg)`.
- [ ] Re-run migration (idempotency): no duplicate rewrites, no errors.
- [ ] Product with `sale_line_warn_msg` set → exception fires on SO confirm. Without message → confirms cleanly.
- [ ] Partner with `sale_warn_msg` set → exception fires. Without message → confirms cleanly.