### PR TITLE
[FIX] sale_order_type_invoice_policy: block prepaid validation on internal pickings

### DIFF
--- a/sale_order_type_invoice_policy/models/stock_picking.py
+++ b/sale_order_type_invoice_policy/models/stock_picking.py
@@ -19,7 +19,7 @@ class StockPicking(models.Model):
         if any(
             self.sudo().filtered(
                 lambda x: (
-                    x.picking_type_id.code == "outgoing"
+                    x.picking_type_id.code in ("outgoing", "internal")
                     and x.sale_id.type_id.invoice_policy in ["prepaid", "prepaid_block_delivery"]
                     and not x._check_sale_paid()
                 )


### PR DESCRIPTION
## Changes

- [FIX] sale_order_type_invoice_policy: block prepaid validation on internal pickings

## Context

In multi-step delivery routes (e.g. Pick + Out), the `button_validate()` check
for prepaid sales was only applied to `outgoing` pickings (WH/OUT), allowing
WH/PICK (type `internal`) to be validated without payment.

The `outgoing`-only restriction was introduced in #1703 to fix a legitimate bug
where customer return receipts (`incoming` pickings linked to a sale via
`group_id`) were being incorrectly blocked. However, that fix was too broad and
excluded `internal` pickings as well.

## Fix

Change `picking_type_id.code == "outgoing"` to
`picking_type_id.code in ("outgoing", "internal")` in `button_validate()`.

This restores the block on PICK steps while keeping `incoming` pickings
(receipts/returns) unaffected — addressing both cases correctly.

`action_assign()` and `stock_move._action_assign()` are intentionally left
unchanged (reserve on PICK remains allowed).

## Test plan

- Sale order with prepaid type + 2-step route (Pick + Out)
- Without payment: attempt to validate WH/PICK → should raise UserError ✓
- With payment: validate WH/PICK → should proceed ✓
- Customer return receipt (incoming, linked to sale) → should not be blocked ✓