### PR TITLE
[FIX] sale_ux: mostrar plantilla de importación de productos sin depender del grupo de listas de precios

### DIFF
--- a/sale_ux/models/product_template.py
+++ b/sale_ux/models/product_template.py
@@ -35,9 +35,7 @@ class ProductTemplate(models.Model):
 
     @api.model
     def get_import_templates(self):
-        if self.env.context.get("sale_multi_pricelist_product_template") and self.env.user.has_group(
-            "product.group_product_pricelist"
-        ):
+        if self.env.context.get("sale_multi_pricelist_product_template"):
             return [
                 {
                     "label": _("Import Template for Products"),


### PR DESCRIPTION
## Contexto

Tarea **65009** — Mejorar plantillas de importación de productos.

En `sale_ux`, el override de `get_import_templates` solo devolvía la plantilla custom de importación de productos si se cumplían **dos** condiciones:

1. El contexto `sale_multi_pricelist_product_template` (que setea la acción de importar productos desde **Ventas**).
2. Que el usuario tuviera el grupo `product.group_product_pricelist` (setting de listas de precios múltiples).

El problema: en clientes de baja complejidad (Business Lite) —que son justamente donde más se usa la carga inicial de datos— las listas de precios no están activadas, por lo que la plantilla custom **nunca aparecía** en Ventas. Sí se mostraba en Compras e Inventario, porque `stock_ux` no aplica ese gate.

## Cambio

Se elimina la dependencia del grupo `product.group_product_pricelist`. La plantilla se muestra siempre que aplique el contexto `sale_multi_pricelist_product_template` (acción de importar productos desde Ventas). La columna de listas de precios del archivo queda inocua para quien no las usa.

```diff
-        if self.env.context.get("sale_multi_pricelist_product_template") and self.env.user.has_group(
-            "product.group_product_pricelist"
-        ):
+        if self.env.context.get("sale_multi_pricelist_product_template"):
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)