### PR TITLE
[IMP] sale_order_type_automation: require company and invoice journal when automation is active

### DIFF
--- a/sale_gathering_automation/tests/test_gathering_invoice_validate_domain.py
+++ b/sale_gathering_automation/tests/test_gathering_invoice_validate_domain.py
@@ -10,10 +10,16 @@ class TestGatheringInvoiceValidateDomain(common.TransactionCase):
         super().setUp()
         self.partner = self.env["res.partner"].create({"name": "Test Gathering Partner"})
         self.product = self.env.ref("product.product_product_4")
+        invoice_journal = self.env["account.journal"].search(
+            [("type", "=", "sale"), ("company_id", "=", self.env.company.id)],
+            limit=1,
+        )
         self.gathering_validate_type = self.env["sale.order.type"].create(
             {
                 "name": "Test Gathering Validate Invoice Domain",
+                "company_id": self.env.company.id,
                 "invoicing_atomation": "validate_invoice",
+                "journal_id": invoice_journal.id,
                 "invoice_validate_domain": "[('move_type', '=', 'out_invoice')]",
             }
         )

--- a/sale_order_type_automation/models/sale_order_type.py
+++ b/sale_order_type_automation/models/sale_order_type.py
@@ -129,6 +129,25 @@ class SaleOrderType(models.Model):
         default = self.env["ir.config_parameter"].sudo().get_param("sale.auto_done_setting", "False")
         self.auto_done_setting = safe_eval(default)
 
+    @api.constrains("invoicing_atomation", "company_id", "invoice_company_id", "journal_id")
+    def _check_invoicing_journal_required(self):
+        # install_mode is True when loading demo/fixture data, where records may
+        # intentionally omit these fields (e.g. company-agnostic demo types).
+        if self.env.context.get("install_mode"):
+            return
+        for rec in self.filtered(lambda x: x.invoicing_atomation != "none"):
+            missing = []
+            if not rec.company_id:
+                missing.append(_("Company"))
+            if not rec.invoice_company_id:
+                missing.append(_("Invoice Company"))
+            if not rec.journal_id:
+                missing.append(_("Invoice Journal"))
+            if missing:
+                raise ValidationError(
+                    _("The following fields are required when invoice automation is active: %s") % ", ".join(missing)
+                )
+
     @api.constrains("payment_atomation", "payment_journal_id")
     def validate_invoicing_atomation(self):
         payment_journal_required = self.filtered(lambda x: x.payment_atomation != "none" and not x.payment_journal_id)

--- a/sale_order_type_automation/tests/test_invoice_automation_error.py
+++ b/sale_order_type_automation/tests/test_invoice_automation_error.py
@@ -21,7 +21,9 @@ class TestInvoiceAutomationError(TestSaleCommon):
         cls.validate_invoice_type = cls.env["sale.order.type"].create(
             {
                 "name": "Test Validate Invoice Automation",
+                "company_id": cls.env.company.id,
                 "invoicing_atomation": "validate_invoice",
+                "journal_id": cls.company_data["default_journal_sale"].id,
             }
         )
         sale_exception_installed = cls.env["sale.order"]._fields.get("ignore_exception")

--- a/sale_order_type_automation/tests/test_sale_order_type_automation.py
+++ b/sale_order_type_automation/tests/test_sale_order_type_automation.py
@@ -14,6 +14,11 @@ class TestSaleOrderTypeAutomation(TransactionCase):
         super().setUpClass()
         cls.partner = cls.env.ref("base.res_partner_1")
         cls.sale_type = cls.env.ref("sale_order_type.normal_sale_type")
+        cls.sale_type.company_id = cls.env.company
+        cls.invoice_journal = cls.env["account.journal"].search(
+            [("type", "=", "sale"), ("company_id", "=", cls.env.company.id)],
+            limit=1,
+        )
         cls.product = cls.env["product.product"].create(
             {
                 "name": "Sale Order Type Automation Product",
@@ -52,6 +57,7 @@ class TestSaleOrderTypeAutomation(TransactionCase):
         self.sale_type.write(
             {
                 "invoicing_atomation": "create_invoice",
+                "journal_id": self.invoice_journal.id,
                 "picking_atomation": "none",
                 "set_done_on_confirmation": False,
                 "invoice_validate_domain": False,
@@ -68,6 +74,7 @@ class TestSaleOrderTypeAutomation(TransactionCase):
         self.sale_type.write(
             {
                 "invoicing_atomation": "validate_invoice",
+                "journal_id": self.invoice_journal.id,
                 "picking_atomation": "none",
                 "invoice_validate_domain": False,
             }

--- a/sale_order_type_automation/views/sale_order_type_views.xml
+++ b/sale_order_type_automation/views/sale_order_type_views.xml
@@ -5,6 +5,15 @@
         <field name="model">sale.order.type</field>
         <field name="inherit_id" ref="sale_order_type.sot_sale_order_type_form_view"/>
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='company_id'][@options]" position="attributes">
+                <attribute name="required">invoicing_atomation != 'none'</attribute>
+            </xpath>
+            <xpath expr="//field[@name='invoice_company_id']" position="attributes">
+                <attribute name="required">invoicing_atomation != 'none'</attribute>
+            </xpath>
+            <xpath expr="//field[@name='journal_id']" position="attributes">
+                <attribute name="required">invoicing_atomation != 'none'</attribute>
+            </xpath>
             <group position="inside">
                 <group string="Automations">
                     <field name="picking_atomation"/>


### PR DESCRIPTION
## Summary

When \`invoicing_atomation\` is set to \`Create Invoice\` or \`Validate Invoice\`, the fields **Company**, **Invoice Company** and **Invoice Journal** are now required. Previously, leaving them empty could cause unexpected behavior (e.g. using the wrong journal or missing company context).

**Changes:**
- \`views/sale_order_type_views.xml\`: adds \`required="invoicing_atomation != 'none'"\` on \`company_id\`, \`invoice_company_id\` and \`journal_id\` via xpath (UI enforcement).
- \`models/sale_order_type.py\`: adds \`_check_invoicing_journal_required\` constraint that validates the three fields server-side (protects against import/export bypass). Skipped during \`install_mode\` to allow demo data with company-agnostic types.

## Test plan

- [ ] Open a sale order type, set Invoicing Automation to \`Create Invoice\` or \`Validate Invoice\` → Company, Invoice Company and Invoice Journal fields turn required (red border)
- [ ] Try to save without one of those fields → form blocks submission
- [ ] Fill all three → save succeeds normally
- [ ] Set Invoicing Automation back to \`None\` → fields are no longer required
- [ ] Existing types with \`invoicing_atomation = none\` are unaffected
- [ ] Importing/exporting a record with automation active but missing journal raises a \`ValidationError\`