### PR TITLE
[IMP] sale_price_checker: cache pricelists-enabled check on res.company

### DIFF
--- a/sale_price_checker/controllers/main.py
+++ b/sale_price_checker/controllers/main.py
@@ -8,18 +8,6 @@ from odoo.tools.misc import format_amount
 
 
 class PriceCheckerController(http.Controller):
-    def _pricelists_enabled(self):
-        """True when the Pricelists feature is turned on in Sales settings.
-
-        Mirrors the way the settings toggle works: pricelists are enabled
-        when ``product.group_product_pricelist`` is implied by
-        ``base.group_user``.
-        """
-        pricelist_group = request.env.ref("product.group_product_pricelist", raise_if_not_found=False)
-        if not pricelist_group:
-            return False
-        return pricelist_group in request.env.ref("base.group_user").sudo().implied_ids
-
     def _resolve(self, company_id=None, pricelist_id=None):
         """Return (company, pricelist) or None if any id is invalid/archived.
 
@@ -42,7 +30,7 @@ class PriceCheckerController(http.Controller):
         if not company:
             return None
 
-        pricelists_enabled = self._pricelists_enabled()
+        pricelists_enabled = request.env["res.company"].sudo()._price_checker_pricelists_enabled()
 
         if pricelist_id is None:
             pricelist = (

--- a/sale_price_checker/models/res_company.py
+++ b/sale_price_checker/models/res_company.py
@@ -2,7 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import fields, models
+from odoo import fields, models, tools
 
 
 class ResCompany(models.Model):
@@ -15,3 +15,10 @@ class ResCompany(models.Model):
         help="Pricelist used by the public price checker for this company. "
         "If empty, the product's Sales Price (lst_price) is used as a fallback.",
     )
+
+    @tools.ormcache(cache="groups")
+    def _price_checker_pricelists_enabled(self):
+        pricelist_group = self.env.ref("product.group_product_pricelist", raise_if_not_found=False)
+        if not pricelist_group:
+            return False
+        return pricelist_group in self.env.ref("base.group_user").sudo().implied_ids


### PR DESCRIPTION
Move the Pricelists-feature check out of the controller into a res.company method decorated with @ormcache(cache="groups"), so it is computed once instead of on every barcode scan. The 'groups' cache group is invalidated automatically (across workers) whenever group implications change -- i.e. when the feature is toggled in Sales > Configuration.