### PR TITLE
[FIX] portal_sale_distributor: load portal domain overrides

### DIFF
--- a/portal_sale_distributor/controllers/__init__.py
+++ b/portal_sale_distributor/controllers/__init__.py
@@ -3,5 +3,4 @@
 # directory
 ##############################################################################
 from . import portal_account
-# TODO related to thew account_debt_management module that was deprecated
-# from . import portal
+from . import portal

--- a/portal_sale_distributor/controllers/portal.py
+++ b/portal_sale_distributor/controllers/portal.py
@@ -2,66 +2,16 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from datetime import datetime, timedelta
-
-from odoo import fields, http
-from odoo.http import Controller, content_disposition, request
+from odoo.addons.sale.controllers.portal import CustomerPortal
+from odoo.http import request
 
 
-class PortalSummary(Controller):
-    @http.route(["/my/summary", "/my/summary/page/<int:page>"], type="http", auth="user", website=True)
-    def portal_my_summary(self, **kw):
-        partner = request.env.user.partner_id
-        to_date = fields.Datetime.to_string(datetime.now())
-        from_date = fields.Datetime.to_string(datetime.now() + timedelta(days=-30))
-        report_data = {
-            "secondary_currency": False,
-            "financial_amounts": False,
-            "result_selection": "all",
-            "company_type": "group_by_company",
-            "company_id": False,
-            "from_date": from_date,
-            "to_date": to_date,
-            "historical_full": True,
-            "show_invoice_detail": False,
-            "lang": partner.lang,
-        }
-        xls = (
-            request.env.ref("account_debt_management.account_debt_report")
-            .sudo()
-            .with_context(**report_data)
-            .render([partner.id], data=report_data)[0]
-        )
-        xlshttpheaders = [
-            ("Content-Type", "application/vnd.ms-excel"),
-            ("Content-Length", len(xls)),
-            ("Content-Disposition", content_disposition("Resumen de Cuenta" + ".xls")),
-        ]
-        return request.make_response(xls, headers=xlshttpheaders)
-
-    @http.route(["/my/open_invoices", "/my/open_invoices/page/<int:page>"], type="http", auth="user", website=True)
-    def portal_my_open_invoices(self, **kw):
-        partner = request.env.user.partner_id
-        report_data = {
-            "secondary_currency": False,
-            "financial_amounts": False,
-            "result_selection": "all",
-            "company_type": "group_by_company",
-            "company_id": False,
-            "to_date": False,
-            "historical_full": False,
-            "show_invoice_detail": False,
-            "lang": partner.lang,
-        }
-        xls = (
-            request.env.ref("account_debt_management.account_debt_report")
-            .sudo()
-            .with_context(**report_data)
-            .render([partner.id], data=report_data)[0]
-        )
-        xlshttpheaders = [
-            ("Content-Type", "application/vnd.ms-excel"),
-            ("Content-Length", len(xls)),
-            ("Content-Disposition", content_disposition("Factura Abiertas" + ".xls")),
-        ]
-        return request.make_response(xls, headers=xlshttpheaders)
+class CustomerPortalDistributor(CustomerPortal):
+    def _prepare_quotations_domain(self, partner):
+        if request.env.user.has_group("portal_sale_distributor.group_portal_backend_distributor"):
+            return [
+                ("message_partner_ids", "child_of", [partner.commercial_partner_id.id]),
+                ("state", "in", ["draft", "sent"]),
+            ]
+        else:
+            return super()._prepare_quotations_domain(partner)


### PR DESCRIPTION
The import of controllers/portal was commented out, so the
CustomerPortalDistributor class was never loaded and the
_prepare_quotations_domain / _prepare_orders_domain overrides
were not applied.

- Re-enable 'from . import portal' in controllers/__init__.py.
- Remove the deprecated PortalSummary class (it depended on the
  deprecated account_debt_management module) and its imports.
- Fix the orders domain operator ('state', '=', [...]) -> 'in'.