### PR TITLE
[FIX] sale_order_type_invoice_policy: restrict internal picking block to delivery chain only

### DIFF
--- a/sale_order_type_invoice_policy/models/stock_picking.py
+++ b/sale_order_type_invoice_policy/models/stock_picking.py
@@ -19,7 +19,11 @@ class StockPicking(models.Model):
         if any(
             self.sudo().filtered(
                 lambda x: (
-                    x.picking_type_id.code in ("outgoing", "internal")
+                    (
+                        x.picking_type_id.code == "outgoing"
+                        or x.picking_type_id
+                        in (x.picking_type_id.warehouse_id.pick_type_id | x.picking_type_id.warehouse_id.pack_type_id)
+                    )
                     and x.sale_id.type_id.invoice_policy in ["prepaid", "prepaid_block_delivery"]
                     and not x._check_sale_paid()
                 )


### PR DESCRIPTION
## Problem

The `button_validate` check for the prepaid invoice policy was blocking validation
of **internal pickings that belong to the inbound (receipt) chain**, specifically
the put-away step in 2-step receipt configurations (e.g. `Almacenamiento`).

### Background

The module blocks picking validation when a sale order uses `prepaid` or
`prepaid_block_delivery` invoice policy and the order hasn't been fully paid.
This is correct for outgoing deliveries.

A prior fix extended the block to `code='internal'` pickings in order to cover
multi-step delivery flows (pick/pack steps before the final outgoing delivery).
The problem is that `code='internal'` is shared by **two very different
operations**:

| Picking type | Chain | Should block? |
|---|---|---|
| `pick_type_id` (e.g. Recolectar) | Delivery — step 1 of pick+ship | ✅ yes |
| `pack_type_id` (e.g. Empaquetar) | Delivery — step 2 of pick+pack+ship | ✅ yes |
| `int_type_id` / put-away (e.g. Almacenamiento) | Receipt — step 2 of 2-step receive | ❌ no |

In MTO flows, the put-away picking inherits `sale_id` from the originating sale
order. When all sale order types have `prepaid_block_delivery` configured, every
MTO put-away step gets incorrectly blocked.

## Fix

Replace the generic `code in ('outgoing', 'internal')` check with explicit
warehouse picking type references:

```python
# Before
x.picking_type_id.code in ("outgoing", "internal")

# After
(
    x.picking_type_id.code == "outgoing"
    or x.picking_type_id in (
        x.picking_type_id.warehouse_id.pick_type_id
        | x.picking_type_id.warehouse_id.pack_type_id
    )
)
```

This uses the warehouse's own `pick_type_id` and `pack_type_id` fields —
which unambiguously point to the delivery-side internal steps — instead of
relying on the shared `code` value.

## Test plan

- [ ] Configure a sale order type with `prepaid_block_delivery` policy
- [ ] Create a sale order (MTO) that triggers a purchase order
- [ ] Set the warehouse to 2-step reception (`reception_steps = two_steps`)
- [ ] Receive the purchase order (step 1: incoming receipt) → should validate OK
- [ ] Validate the put-away step (step 2: internal/Almacenamiento) → should validate OK ← **regression fixed**
- [ ] Create a sale order with the same policy, set delivery to 3-step (`pick_pack_ship`)
- [ ] Try to validate the Recolectar step without paying → should raise error ✅
- [ ] Try to validate the Empaquetar step without paying → should raise error ✅
- [ ] Pay the sale order fully, then validate all steps → should work ✅