### PR TITLE
[FIX] sale_gathering: exclude cancelled down payments from gathering …

### DIFF
--- a/sale_gathering/models/sale_order.py
+++ b/sale_gathering/models/sale_order.py
@@ -33,6 +33,7 @@ class SaleOrder(models.Model):
         "order_line.product_uom_qty",
         "order_line.is_downpayment",
         "order_line.quantity_returned",
+        "order_line.invoice_lines.parent_state",
     )
     def _compute_gathering_balance(self):
         orders_gathering = self.filtered(
@@ -44,7 +45,7 @@ class SaleOrder(models.Model):
         for order in orders_gathering:
             lines = order._get_gathering_lines()
             total_downpayment_amount = 0
-            for line in lines.filtered("is_downpayment"):
+            for line in lines.filtered(lambda l: l.is_downpayment and l._get_downpayment_state() != "cancel"):
                 total_downpayment_amount += line.tax_id.with_context(round=False).compute_all(
                     line.price_unit,
                     currency=line.currency_id,


### PR DESCRIPTION
…balance

A cancelled down payment line was still counted in gathering_balance, inflating the balance (and withdrawn_amount). Skip lines whose down payment state is 'cancel' and depend on order_line.invoice_lines.parent_state so the balance recomputes when the related down payment invoice is cancelled.

Partial backport of ingadhoc/sale#1730 (19.0) to 18.0.