### PR TITLE
[IMP] sale_order_type_automation: add sale_order_filter_domain for au…

### DIFF
--- a/sale_order_type_automation/models/sale_order.py
+++ b/sale_order_type_automation/models/sale_order.py
@@ -25,6 +25,18 @@ class SaleOrder(models.Model):
         ):
             # we take into account if there are any transaction finish from the e-commerce
             #  and not continue with the automation in this case
+            skip_validation = False
+            if rec.type_id.sale_order_filter_domain:
+                so_domain = safe_eval(
+                    rec.type_id.sale_order_filter_domain,
+                    {
+                        "datetime": safe_eval_datetime,
+                        "context_today": lambda: fields.Date.context_today(rec),
+                        "relativedelta": safe_eval_dateutil.relativedelta.relativedelta,
+                    },
+                )
+                if so_domain and rec.filtered_domain(so_domain):
+                    skip_validation = True
             if (
                 rec.transaction_ids
                 and rec.env["ir.config_parameter"].sudo().get_param("sale.automatic_invoice")
@@ -40,7 +52,11 @@ class SaleOrder(models.Model):
             if not invoices:
                 continue
 
-            if rec.type_id.invoicing_atomation == "validate_invoice" and not rec.type_id.background_post:
+            if (
+                rec.type_id.invoicing_atomation == "validate_invoice"
+                and not rec.type_id.background_post
+                and not skip_validation
+            ):
                 if rec._context.get("commit_invoice_automation"):
                     rec.env.cr.commit()
                 try:

--- a/sale_order_type_automation/models/sale_order_type.py
+++ b/sale_order_type_automation/models/sale_order_type.py
@@ -104,6 +104,10 @@ class SaleOrderType(models.Model):
         string="Invoice Validation Domain",
         help="Domain to filter invoices for automatic validation. So, if this filter does NOT find the invoices, they stay in drafts status.",
     )
+    sale_order_filter_domain = fields.Char(
+        string="Draft sale order domain",
+        help="This sales filter allows you to create some invoices in draft form without automatically validating them. Therefore, if the condition is met, the invoice remains in draft status.",
+    )
 
     @api.depends("payment_atomation")
     def _compute_payment_journal_id(self):

--- a/sale_order_type_automation/views/sale_order_type_views.xml
+++ b/sale_order_type_automation/views/sale_order_type_views.xml
@@ -17,6 +17,7 @@
                     <field name="invoicing_atomation"/>
                     <field name="background_post" invisible="invoicing_atomation != 'validate_invoice'"/>
                     <field name="invoice_validate_domain" widget="domain" options="{'model': 'account.move', 'allow_expressions': True, 'no_create': True, 'in_dialog': False, 'foldable': True}" invisible="invoicing_atomation != 'validate_invoice'"/>
+                    <field name="sale_order_filter_domain" widget="domain" options="{'model': 'sale.order', 'allow_expressions': True, 'no_create': True, 'in_dialog': False, 'foldable': True}" invisible="invoicing_atomation != 'validate_invoice'"/>
                     <field name="payment_atomation"/>
                     <field name="payment_journal_id" required="payment_atomation != 'none'"/>
                     <field name="set_done_on_confirmation" invisible="auto_done_setting"/>


### PR DESCRIPTION
…to-validation exclusion

Agrega `sale_order_filter_domain` en `sale.order.type`: si la orden de venta matchea el domain configurado, se crea la factura pero no se valida automáticamente (queda en borrador).