### PR TITLE
[FIX] sale_gathering: count only paid down payments in gathering balance

### DIFF
--- a/sale_gathering/models/sale_order.py
+++ b/sale_gathering/models/sale_order.py
@@ -45,7 +45,15 @@ class SaleOrder(models.Model):
         for order in orders_gathering:
             lines = order._get_gathering_lines()
             total_downpayment_amount = 0
-            for line in lines.filtered(lambda l: l.is_downpayment and l._get_downpayment_state() != "cancel"):
+            for line in lines.filtered(
+                lambda l: l.is_downpayment
+                and not l.display_type
+                and any(
+                    il.parent_state != "cancel"
+                    for il in l.invoice_lines
+                    if len(il.move_id.invoice_line_ids.sale_line_ids.filtered("is_downpayment")) == 1
+                )
+            ):
                 total_downpayment_amount += line.tax_id.with_context(round=False).compute_all(
                     line.price_unit,
                     currency=line.currency_id,


### PR DESCRIPTION
The previous fix excluded lines with dp_state == 'cancel', but when a duplicate anticipo line exists with mixed invoice states (e.g. a shared posted canje invoice plus a never-posted draft anticipo), _get_downpayment_state() returns '' for both lines and neither gets excluded.

Replace the dp_state check with a payment-based criterion: a down payment line counts in gathering_balance only if it has at least one out_invoice whose payment_state is 'paid' or 'in_payment'. This correctly excludes phantom lines whose original anticipo was never posted/paid, while including legitimate paid anticios regardless of any canje/NC also linked.

Update the depends accordingly to track payment_state changes.

Closes #115776