### PR TITLE
[FIX] sale_order_type_automation: wrap auto payment in savepoint

### DIFF
--- a/sale_order_type_automation/models/account_move.py
+++ b/sale_order_type_automation/models/account_move.py
@@ -45,7 +45,8 @@ class AccountMove(models.Model):
             and x.sale_type_id.payment_atomation == "validate_payment"
         ):
             try:
-                self._register_payment_invoice(invoice, invoice.sale_type_id.payment_journal_id)
+                with self.env.cr.savepoint():
+                    self._register_payment_invoice(invoice, invoice.sale_type_id.payment_journal_id)
             except Exception as error:
                 message = "Could not automatically create and validate payment. Error: %s" % error
                 invoice.message_post(body=message)


### PR DESCRIPTION
### Problem

`sale_order_type_automation` registers the automatic payment inside a `try/except` in `AccountMove.action_post`, but **without a savepoint**. When `_register_payment_invoice` raises a database-level error (psycopg2), the transaction is left aborted. The `except` branch then calls `invoice.message_post()`, which issues SQL on the already-aborted transaction and raises `InFailedSqlTransaction`. That second error propagates instead of the original one, so the confirmation fails and the real payment error is never recorded anywhere.

### Fix

Wrap `_register_payment_invoice` in `with self.env.cr.savepoint():`. On failure the cursor is rolled back to a clean state, so `message_post` succeeds and records the actual error on the invoice chatter, keeping the transaction consistent. This mirrors the pattern already used by `run_invoicing_atomation` in `sale_order.py` of the same module.

### Test plan

- Configure a sale order type with `payment_atomation = validate_payment` and a payment journal whose automatic payment registration fails at DB level.
- Confirm an order so the automation posts the invoice and tries to register the payment.
- Before: the invoice is posted but confirmation raises `InFailedSqlTransaction`; no error is recorded.
- After: the invoice is posted, the payment failure is caught, and the real error is logged in the invoice chatter.

Ref: ticket 121857