### PR TITLE
[FIX] sale_order_type_automation: recover aborted transaction on auto…

### DIFF
--- a/sale_order_type_automation/models/account_move.py
+++ b/sale_order_type_automation/models/account_move.py
@@ -2,7 +2,12 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
+import logging
+
+import psycopg2
 from odoo import fields, models
+
+_logger = logging.getLogger(__name__)
 
 
 class AccountMove(models.Model):
@@ -48,5 +53,15 @@ class AccountMove(models.Model):
                 self._register_payment_invoice(invoice, invoice.sale_type_id.payment_journal_id)
             except Exception as error:
                 message = "Could not automatically create and validate payment. Error: %s" % error
-                invoice.message_post(body=message)
+                try:
+                    invoice.message_post(body=message)
+                except psycopg2.Error:
+                    invoice.env.cr.rollback()
+                    _logger.warning(
+                        "The payment automation transaction of invoice %s was "
+                        "aborted, recovering before logging the failure: %s",
+                        invoice.ids,
+                        error,
+                    )
+                    invoice.message_post(body=message)
         return res

--- a/sale_order_type_automation/models/sale_order.py
+++ b/sale_order_type_automation/models/sale_order.py
@@ -2,6 +2,9 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
+import logging
+
+import psycopg2
 from odoo import _, fields, models
 from odoo.exceptions import UserError
 from odoo.tools.safe_eval import (
@@ -9,6 +12,8 @@ from odoo.tools.safe_eval import (
     dateutil as safe_eval_dateutil,
     safe_eval,
 )
+
+_logger = logging.getLogger(__name__)
 
 
 class SaleOrder(models.Model):
@@ -79,8 +84,22 @@ class SaleOrder(models.Model):
                         "invoices (ids %s), you will need to validate them"
                         " manually. This is what we get: %s"
                     ) % (invoices.ids, error)
-                    invoices.message_post(body=message)
-                    rec.message_post(body=message)
+                    self._log_invoicing_automation_error(rec, invoices, message, error)
+
+    def _log_invoicing_automation_error(self, order, invoices, message, error):
+        try:
+            invoices.message_post(body=message)
+            order.message_post(body=message)
+        except psycopg2.Error:
+            order.env.cr.rollback()
+            _logger.warning(
+                "The invoicing automation transaction of sale order %s was "
+                "aborted, recovering before logging the failure: %s",
+                order.ids,
+                error,
+            )
+            invoices.message_post(body=message)
+            order.message_post(body=message)
 
     def run_picking_automation(self):
         # If there products are the type 'service' equals the

--- a/sale_order_type_automation/tests/test_invoice_automation_error.py
+++ b/sale_order_type_automation/tests/test_invoice_automation_error.py
@@ -2,8 +2,9 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import psycopg2
 from odoo.addons.sale.tests.common import TestSaleCommon
 from odoo.tests import tagged
 
@@ -73,4 +74,70 @@ class TestInvoiceAutomationError(TestSaleCommon):
         self.assertTrue(
             any("ARCA timeout" in (m.body or "") for m in so.message_ids),
             "Se esperaba mensaje de error en el chatter de la orden de venta",
+        )
+
+    def test_db_error_on_action_post_does_not_break_confirmation(self):
+        """Un error a nivel DB al validar la factura deja la transacción abortada;
+        el aviso de fallo no debe filtrar InFailedSqlTransaction ni tumbar la
+        confirmación: el cursor se recupera y el mensaje se re-postea en la
+        factura y la orden (tickets #121857 / #121927; comportamiento de 67846).
+
+        La caída real (savepoint destruido por el commit del CAE + error DB) no se
+        puede reproducir íntegra en un TransactionCase: el framework prohíbe el
+        rollback real y, sin commit, cualquier recuperación borraría los registros
+        del test. Simulamos el síntoma exacto: action_post revienta (se entra al
+        except) y el primer message_post falla con InFailedSqlTransaction, que es
+        donde el bug tumbaba todo."""
+        so = self._create_so()
+        AccountMove = self.env["account.move"]
+        Move = type(AccountMove)
+        orig_action_post = Move.action_post
+        orig_message_post = Move.message_post
+
+        def _failing_action_post(records, *args, **kwargs):
+            # Crea/postea la factura de verdad y luego falla la validación: el
+            # savepoint revierte el posteo (factura queda en draft) y se entra al
+            # except de run_invoicing_atomation, igual que en producción.
+            orig_action_post(records, *args, **kwargs)
+            raise Exception("automatic invoice validation failed")
+
+        state = {"aborted": False}
+
+        def _message_post_aborted_once(records, *args, **kwargs):
+            body = kwargs.get("body") or (args[0] if args else "")
+            if "couldn't validate" in (body or "") and not state["aborted"]:
+                # Primer intento de dejar el aviso: la tx está abortada.
+                state["aborted"] = True
+                raise psycopg2.errors.InFailedSqlTransaction("current transaction is aborted, commands ignored")
+            return orig_message_post(records, *args, **kwargs)
+
+        rollback_mock = MagicMock()
+        logger = "odoo.addons.sale_order_type_automation.models.sale_order"
+        with patch.object(Move, "action_post", _failing_action_post), patch.object(
+            Move, "message_post", _message_post_aborted_once
+        ), patch.object(so.env.cr, "rollback", rollback_mock), self.assertLogs(logger, level="WARNING") as log_catcher:
+            try:
+                so.action_confirm()
+            except psycopg2.Error as error:
+                self.fail("action_confirm() leaked a database error instead of " "handling it gracefully: %r" % error)
+
+        # Se intentó postear el aviso, falló por tx abortada y el fix lo detectó.
+        self.assertTrue(state["aborted"], "The first message_post should have failed")
+        # El fix recuperó la transacción en lugar de tumbar la confirmación.
+        self.assertTrue(
+            rollback_mock.called,
+            "The aborted transaction should have been rolled back",
+        )
+        self.assertTrue(
+            any("aborted, recovering" in line for line in log_catcher.output),
+            "The aborted-transaction recovery should be logged, got: %s" % log_catcher.output,
+        )
+        # Tras recuperar, el aviso quedó en el chatter de la factura y de la orden.
+        self.assertTrue(
+            any("couldn't validate" in (m.body or "").lower() for m in so.message_ids),
+            "The validation failure should be logged on the sale order chatter",
+        )
+        self.assertTrue(
+            so.invoice_ids and any("couldn't validate" in (m.body or "").lower() for m in so.invoice_ids.message_ids),
+            "The validation failure should be logged on the invoice chatter",
         )


### PR DESCRIPTION
…mation failure

When action_post (or the automatic payment registration) fails with a database-level error that aborts the transaction -- e.g. the AR e-invoice code commits the CAE and discards the savepoint opened around action_post, and a later error leaves the cursor aborted -- posting the failure notice over the broken cursor raised InFailedSqlTransaction, tearing down the whole order confirmation and masking the real error.

Recover the transaction before posting the failure notice on the invoice and the sale order, so the confirmation is not torn down and the real error is not masked. The savepoint behaviour for recoverable errors (invoice kept in draft, error logged on invoice and sale order) is preserved.

Tickets: 121857, 121927