### PR TITLE
[FIX] sale_order_type_automation: inherit from sale_order_type_ux form view

### DIFF
--- a/sale_order_type_automation/views/sale_order_type_views.xml
+++ b/sale_order_type_automation/views/sale_order_type_views.xml
@@ -3,7 +3,7 @@
     <record id="sot_sale_order_type_form_view" model="ir.ui.view">
         <field name="name">sale.order.type.form.view</field>
         <field name="model">sale.order.type</field>
-        <field name="inherit_id" ref="sale_order_type.sot_sale_order_type_form_view"/>
+        <field name="inherit_id" ref="sale_order_type_ux.sale_order_type_form_view"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='company_id'][@options]" position="attributes">
                 <attribute name="required">invoicing_atomation != 'none'</attribute>

--- a/sale_order_type_ux/views/sale_order_type_views.xml
+++ b/sale_order_type_ux/views/sale_order_type_views.xml
@@ -35,9 +35,9 @@
                 <field name="invoice_company_id" options="{'no_create': True}"/>
             </field>
             <xpath expr="//field[@name='sequence_id']" position="before">
-                <field name="warehouse_id" options="{'no_create': True}"/>/>
-                <field name="company_id" options="{'no_create': True}"/>/>
-                <field name="pricelist_id" options="{'no_create': True}"/>/>
+                <field name="warehouse_id" options="{'no_create': True}"/>
+                <field name="company_id" options="{'no_create': True}"/>
+                <field name="pricelist_id" options="{'no_create': True}"/>
             </xpath>
 
              <field name="payment_term_id" position="after">


### PR DESCRIPTION
## Problem

`sale_order_type_automation`'s form view extends the base OCA `sale_order_type` view directly with an xpath on `//field[@name='company_id'][@options]`, relying on the `options` attribute that `sale_order_type_ux` adds to that field.

Both views inherit from the same parent with equal priority, so combination order falls back to record id. Since automation's view has a lower id than ux's, it gets combined first — at that point no `company_id` field has an `options` attribute yet, and view validation fails:

```
odoo.exceptions.ValidationError: El elemento "<xpath expr="//field[@name='company_id'][@options]">" no se puede localizar en la vista principal
```

Same issue affects the `//field[@name='invoice_company_id']` xpath in the same view — that field is also added by `sale_order_type_ux`.

## Fix

Make `sale_order_type_automation`'s view inherit from `sale_order_type_ux.sale_order_type_form_view` instead of the shared base view. `sale_order_type_automation` already depends on `sale_order_type_ux` in its manifest, so this only makes the view hierarchy match the existing module dependency — combination order is now guaranteed structurally instead of relying on record id tie-breaking.

Also removes a stray duplicated `/>` left over on the `warehouse_id`/`company_id`/`pricelist_id` field tags added by `sale_order_type_ux` (harmless text node, but clearly a copy-paste leftover).

## Test plan

- [ ] Install/upgrade `sale_order_type_automation` on a clean 19.0 database and confirm the `sale.order.type` form view opens without a `ValidationError`.
- [ ] Confirm `company_id` and `invoice_company_id` still show as `required` when `invoicing_atomation != 'none'`.