### PR TITLE
[IMP] sale_ux: prevent re-confirming an already confirmed sale order

### DIFF
--- a/sale_ux/README.rst
+++ b/sale_ux/README.rst
@@ -49,6 +49,7 @@ Several Improvements to sales:
 #. Prevents writing in certain fields in blocked sales orders.
 #. Deleting price lists with confirmed sale orders is not permitted.
 #. Prevents deleting sale orders when they have associated invoices, preserving traceability.
+#. Prevents re-confirming a sale order that is already confirmed, raising a clear error message.
 
 Installation
 ============

--- a/sale_ux/i18n/es.po
+++ b/sale_ux/i18n/es.po
@@ -712,6 +712,12 @@ msgstr ""
 #. module: sale_ux
 #. odoo-python
 #: code:addons/sale_ux/models/sale_order.py:0
+msgid "The sale order %s is already confirmed."
+msgstr "El pedido de venta %s ya está confirmado."
+
+#. module: sale_ux
+#. odoo-python
+#: code:addons/sale_ux/models/sale_order.py:0
 msgid "This quotation has been automatically canceled due to its expiration."
 msgstr ""
 "Esta cotización ha sido cancelada automáticamente debido a su vencimiento."

--- a/sale_ux/i18n/sale_ux.pot
+++ b/sale_ux/i18n/sale_ux.pot
@@ -691,6 +691,12 @@ msgstr ""
 #. module: sale_ux
 #. odoo-python
 #: code:addons/sale_ux/models/sale_order.py:0
+msgid "The sale order %s is already confirmed."
+msgstr ""
+
+#. module: sale_ux
+#. odoo-python
+#: code:addons/sale_ux/models/sale_order.py:0
 msgid "This quotation has been automatically canceled due to its expiration."
 msgstr ""
 

--- a/sale_ux/models/sale_order.py
+++ b/sale_ux/models/sale_order.py
@@ -105,6 +105,12 @@ class SaleOrder(models.Model):
         lines_to_recompute = self.order_line.filtered(lambda line: not line.display_type)
         lines_to_recompute._compute_tax_ids()
 
+    def action_confirm(self):
+        for order in self:
+            if order.state == "sale":
+                raise UserError(self.env._("The sale order %s is already confirmed.", order.display_name))
+        return super().action_confirm()
+
     def action_cancel(self):
         invoice_lines = self.sudo().env["account.move.line"].search([("sale_line_ids", "in", self.order_line.ids)])
         moves = invoice_lines.mapped("move_id").filtered(

--- a/sale_ux/tests/test_sale_order.py
+++ b/sale_ux/tests/test_sale_order.py
@@ -85,6 +85,14 @@ class TestSaleOrder(SaleUxCommon):
         self.assertNotIn(excluded_line, lines)
         self.assertIn(order.order_line[1], lines)
 
+    def test_confirm_already_confirmed_raises(self):
+        order = self._create_sale_order()
+        order.action_confirm()
+        self.assertEqual(order.state, "sale")
+
+        with self.assertRaises(UserError):
+            order.action_confirm()
+
     def test_locked_order_blocks_protected_fields(self):
         order = self._create_sale_order()
         order.action_confirm()


### PR DESCRIPTION
Raise a clear UserError when action_confirm is called on a sale order already in 'sale' state, instead of the generic native message. Add Spanish translation, README entry and test.