### PR TITLE
[IMP] sale_ux: prevent re-confirming an already confirmed sale order

### DIFF
--- a/sale_ux/README.rst
+++ b/sale_ux/README.rst
@@ -49,6 +49,7 @@ Several Improvements to sales:
 #. Add the field "Un-invoiced" (amount_uninvoiced) in the sale order to show the uninvoiced amount.
 #. Prevents writing in certain fields in blocked sales orders.
 #. Deleting price lists with confirmed sale orders is not permitted.
+#. Prevents re-confirming a sale order that is already confirmed, raising a clear error message.
 
 Installation
 ============

--- a/sale_ux/i18n/es.po
+++ b/sale_ux/i18n/es.po
@@ -525,6 +525,12 @@ msgstr "Impuestos"
 #. module: sale_ux
 #. odoo-python
 #: code:addons/sale_ux/models/sale_order.py:0
+msgid "The sale order %s is already confirmed."
+msgstr "El pedido de venta %s ya está confirmado."
+
+#. module: sale_ux
+#. odoo-python
+#: code:addons/sale_ux/models/sale_order.py:0
 msgid "This quotation has been automatically canceled due to its expiration."
 msgstr ""
 "Esta cotización ha sido cancelada automáticamente debido a su vencimiento."

--- a/sale_ux/models/sale_order.py
+++ b/sale_ux/models/sale_order.py
@@ -94,6 +94,12 @@ class SaleOrder(models.Model):
         lines_to_recompute = self.order_line.filtered(lambda line: not line.display_type)
         lines_to_recompute._compute_tax_id()
 
+    def action_confirm(self):
+        for order in self:
+            if order.state == "sale":
+                raise UserError(_("The sale order %s is already confirmed.") % order.display_name)
+        return super().action_confirm()
+
     def action_cancel(self):
         invoice_lines = self.sudo().env["account.move.line"].search([("sale_line_ids", "in", self.order_line.ids)])
         moves = invoice_lines.mapped("move_id").filtered(


### PR DESCRIPTION
Raise a clear UserError when action_confirm is called on a sale order already in 'sale' state, instead of the generic native message. Add Spanish translation, README entry and test.
