### PR TITLE
[FIX] sale_gathering_automation: pass first_gathering_invoice context…

### DIFF
--- a/sale_gathering_automation/models/sale_order.py
+++ b/sale_gathering_automation/models/sale_order.py
@@ -80,7 +80,7 @@ class SaleOrder(models.Model):
             ):
                 advance_payment_wizard = (
                     self.env["sale.advance.payment.inv"]
-                    .with_context()
+                    .with_context(first_gathering_invoice=True)
                     .create(
                         {
                             "advance_payment_method": "fixed",


### PR DESCRIPTION
… when creating gathering invoice

When confirming a gathering sale order with automation, _create_invoices was called without the first_gathering_invoice=True context. This caused _prepare_base_line_for_taxes_computation to use product_uom_qty (already 0 after _action_confirm) instead of initial_qty_gathered, resulting in an empty gathering invoice that failed automatic validation.