### PR TITLE
[IMP] sale_loyalty_ux: block loyalty domains using '=' against a list

### DIFF
--- a/sale_loyalty_ux/README.rst
+++ b/sale_loyalty_ux/README.rst
@@ -16,6 +16,7 @@ Sale Loyalty UX
 
 #. Adds the capability of filtering sale orders in a Loyalty program
 #. Shows a blue reminder banner on draft/sent sale orders when claimable rewards are available and no reward has been applied yet
+#. Validates loyalty domains and blocks saving a domain that uses the '=' / '!=' operator against a list value (which floods the logs on every recompute), forcing the 'in' / 'not in' operator instead
 
 Installation
 ============

--- a/sale_loyalty_ux/i18n/es.po
+++ b/sale_loyalty_ux/i18n/es.po
@@ -28,6 +28,17 @@ msgid "<span>There are available rewards that apply to this Sales Order</span>"
 msgstr ""
 
 #. module: sale_loyalty_ux
+#. odoo-python
+#: code:addons/sale_loyalty_ux/models/loyalty_domain.py:0
+msgid ""
+"Invalid domain syntax: operator '%(operator)s' cannot be used with a list "
+"value %(value)s. Use 'in' or 'not in' instead."
+msgstr ""
+"Sintaxis de dominio inválida: el operador '%(operator)s' no puede usarse con "
+"un valor de tipo lista %(value)s. Utilice 'está en' (in) o 'no está en' (not "
+"in) en su lugar."
+
+#. module: sale_loyalty_ux
 #: model:ir.model.fields,field_description:sale_loyalty_ux.field_loyalty_program__display_name
 #: model:ir.model.fields,field_description:sale_loyalty_ux.field_sale_order__display_name
 msgid "Display Name"

--- a/sale_loyalty_ux/i18n/sale_loyalty_ux.pot
+++ b/sale_loyalty_ux/i18n/sale_loyalty_ux.pot
@@ -22,6 +22,14 @@ msgid ""
 msgstr ""
 
 #. module: sale_loyalty_ux
+#. odoo-python
+#: code:addons/sale_loyalty_ux/models/loyalty_domain.py:0
+msgid ""
+"Invalid domain syntax: operator '%(operator)s' cannot be used with a list "
+"value %(value)s. Use 'in' or 'not in' instead."
+msgstr ""
+
+#. module: sale_loyalty_ux
 #: model:ir.model.fields,field_description:sale_loyalty_ux.field_loyalty_program__display_name
 #: model:ir.model.fields,field_description:sale_loyalty_ux.field_sale_order__display_name
 msgid "Display Name"

--- a/sale_loyalty_ux/models/__init__.py
+++ b/sale_loyalty_ux/models/__init__.py
@@ -4,3 +4,4 @@
 ##############################################################################
 from . import sale_order
 from . import loyalty_program
+from . import loyalty_rule

--- a/sale_loyalty_ux/models/loyalty_rule.py
+++ b/sale_loyalty_ux/models/loyalty_rule.py
@@ -4,21 +4,19 @@
 ##############################################################################
 import ast
 
-from odoo import api, fields, models
+from odoo import api, models
 from odoo.exceptions import ValidationError
 from odoo.fields import Domain
 
 
-class LoyaltyProgram(models.Model):
-    _inherit = "loyalty.program"
+class LoyaltyRule(models.Model):
+    _inherit = "loyalty.rule"
 
-    sale_domain = fields.Char(default="[]")
-
-    @api.constrains("sale_domain")
-    def _check_sale_domain(self):
-        for program in self:
-            if program.sale_domain and program.sale_domain != "[]":
-                for condition in Domain(ast.literal_eval(program.sale_domain)).iter_conditions():
+    @api.constrains("product_domain")
+    def _check_product_domain(self):
+        for rule in self:
+            if rule.product_domain and rule.product_domain != "[]":
+                for condition in Domain(ast.literal_eval(rule.product_domain)).iter_conditions():
                     if condition.operator in ("=", "!=") and isinstance(condition.value, (list, tuple)):
                         raise ValidationError(
                             self.env._(
@@ -28,10 +26,3 @@ class LoyaltyProgram(models.Model):
                                 value=condition.value,
                             )
                         )
-
-    def _get_valid_sale_order(self):
-        domain = []
-        if self.sale_domain and self.sale_domain != "[]":
-            domain = Domain.AND([domain, ast.literal_eval(self.sale_domain)])
-            return domain
-        return False

--- a/sale_loyalty_ux/tests/__init__.py
+++ b/sale_loyalty_ux/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_sale_order_loyalty_banner
+from . import test_loyalty_domain_operator

--- a/sale_loyalty_ux/tests/test_loyalty_domain_operator.py
+++ b/sale_loyalty_ux/tests/test_loyalty_domain_operator.py
@@ -1,0 +1,51 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+
+
+class TestLoyaltyDomainOperator(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.program = cls.env["loyalty.program"].create(
+            {
+                "name": "Test Program",
+                "program_type": "promotion",
+            }
+        )
+        cls.rule = cls.env["loyalty.rule"].create(
+            {
+                "program_id": cls.program.id,
+            }
+        )
+
+    def test_sale_domain_equal_against_list_is_rejected(self):
+        with self.assertRaises(ValidationError):
+            self.program.sale_domain = "[('partner_id.category_id', '=', [21])]"
+
+    def test_sale_domain_not_equal_against_list_is_rejected(self):
+        with self.assertRaises(ValidationError):
+            self.program.sale_domain = "[('partner_id.category_id', '!=', [21])]"
+
+    def test_sale_domain_in_operator_is_allowed(self):
+        self.program.sale_domain = "[('partner_id.category_id', 'in', [21])]"
+        self.assertEqual(self.program.sale_domain, "[('partner_id.category_id', 'in', [21])]")
+
+    def test_sale_domain_equal_against_scalar_is_allowed(self):
+        self.program.sale_domain = "[('partner_id.category_id', '=', 21)]"
+        self.assertEqual(self.program.sale_domain, "[('partner_id.category_id', '=', 21)]")
+
+    def test_product_domain_equal_against_list_is_rejected(self):
+        with self.assertRaises(ValidationError):
+            self.rule.product_domain = "[('categ_id', '=', [3])]"
+
+    def test_product_domain_in_operator_is_allowed(self):
+        self.rule.product_domain = "[('categ_id', 'in', [3])]"
+        self.assertEqual(self.rule.product_domain, "[('categ_id', 'in', [3])]")
+
+    def test_empty_domain_is_allowed(self):
+        self.program.sale_domain = "[]"
+        self.assertEqual(self.program.sale_domain, "[]")


### PR DESCRIPTION
Domains stored on loyalty programs/rules from the web builder using the '=' (or '!=') operator against a list value, e.g.
[('partner_id.category_id', '=', [21])], make Odoo's domain parser log a warning on every sale order recompute, flooding production logs.

Add an @api.constrains on loyalty.program.sale_domain and loyalty.rule.product_domain that walks the domain with odoo.fields.Domain.iter_conditions() and blocks saving such a domain, forcing the 'in' / 'not in' operator instead.

Task #70341