### PR TITLE
[FIX] portal_sale_distributor_event: add event_sale dependency for ACL model references

### DIFF
--- a/portal_sale_distributor_event/__manifest__.py
+++ b/portal_sale_distributor_event/__manifest__.py
@@ -27,6 +27,7 @@
     "license": "AGPL-3",
     "depends": [
         "event",
+        "event_sale",
         "portal_sale_distributor",
     ],
     "demo": [],


### PR DESCRIPTION
## Summary

`portal_sale_distributor_event`'s `security/ir.model.access.csv` references three models defined in `event_sale` (`event.event.configurator`, `registration.editor`, `registration.editor.line`), but the module's `depends` only listed `event` and `portal_sale_distributor`.

This worked as long as `event_sale` happened to be installed alongside it, but fails to load standalone with:

```
No matching record found for external id 'event_sale.model_event_event_configurator' in field 'Model'
No matching record found for external id 'event_sale.model_registration_editor_line' in field 'Model'
No matching record found for external id 'event_sale.model_registration_editor' in field 'Model'
```

- Add `event_sale` to `depends` so the ACL external ids resolve correctly on a standalone install (auto_install continues to trigger on `event` + `event_sale` + `portal_sale_distributor`).

## Test plan

- [ ] Install `portal_sale_distributor_event` without pre-installing `event_sale` manually and confirm it loads without ACL errors.