### PR TITLE
[FIX] sale_order_type_invoice_policy: cover custom pick/pack picking types in prepaid block

### DIFF
--- a/sale_order_type_invoice_policy/models/stock_picking.py
+++ b/sale_order_type_invoice_policy/models/stock_picking.py
@@ -19,11 +19,7 @@ class StockPicking(models.Model):
         if any(
             self.sudo().filtered(
                 lambda x: (
-                    (
-                        x.picking_type_id.code == "outgoing"
-                        or x.picking_type_id
-                        in (x.picking_type_id.warehouse_id.pick_type_id | x.picking_type_id.warehouse_id.pack_type_id)
-                    )
+                    x._is_delivery_chain()
                     and x.sale_id.type_id.invoice_policy in ["prepaid", "prepaid_block_delivery"]
                     and not x._check_sale_paid()
                 )
@@ -65,3 +61,19 @@ class StockPicking(models.Model):
         ):
             return False
         return True
+
+    def _is_delivery_chain(self):
+        """Whether this picking's moves eventually reach a customer location.
+
+        Identifies pick/pack/out steps regardless of how many intermediate
+        picking types a warehouse defines (e.g. several custom Pick
+        operation types per product category), instead of relying on the
+        single warehouse.pick_type_id/pack_type_id references, which only
+        cover the default 3-step route and miss any extra custom ones.
+        Return/receipt pickings are excluded naturally, since their moves
+        never end up in a customer location.
+        """
+        self.ensure_one()
+        moves = self.move_ids
+        dest_moves = moves.browse(moves._rollup_move_dests())
+        return bool((moves | dest_moves).filtered(lambda m: m.location_dest_id.usage == "customer"))


### PR DESCRIPTION
## Summary

`button_validate()` identified pick/pack steps of the delivery chain by comparing the picking's `picking_type_id` against the warehouse's single `pick_type_id`/`pack_type_id` fields (plus `code == "outgoing"` for the final step). This only covers the default 3-step route. A warehouse with extra custom picking types — e.g. a separate Pick operation per product category — has pickings that match neither the warehouse's `pick_type_id`/`pack_type_id` nor `outgoing`, so the `prepaid`/`prepaid_block_delivery` validation block was silently skipped for those transfers.

## Fix

Replaces the picking-type comparison with a location-based check (`_is_delivery_chain`): a picking is considered part of the delivery chain if any of its moves — or their moves further down the chain via `_rollup_move_dests` — reach a `customer` location. This covers any number of intermediate operation types a warehouse defines, without needing to special-case them individually. Return/receipt pickings keep being excluded naturally, since their moves never end up in a customer location.

## Test plan

- Sale order with a type using `invoice_policy = prepaid_block_delivery`, unpaid invoice, on a warehouse with more than one Pick-type operation type (i.e. a custom one not set as `warehouse.pick_type_id`) — validating that Pick picking should now raise the `UserError` instead of going through.
- Regression: standard 3-step delivery (Pick/Pack/Out) on a default warehouse still blocks as before.
- Regression: 2-step receipt (put-away) linked to the same sale via MTO is not blocked (its moves end at an internal location, not customer).