### PR TITLE
[FIX] portal_sale_distributor: add ir.rule to allow distributors to r…

### DIFF
--- a/portal_sale_distributor/security/portal_sale_distributor_security.xml
+++ b/portal_sale_distributor/security/portal_sale_distributor_security.xml
@@ -58,4 +58,20 @@
         <field eval="0" name="perm_unlink"/>
     </record>
 
+    <!-- Portal distributors need to read the Odoo company partner(s) they belong
+         to. The sale order form reads company_id.partner_id during rendering and
+         onchanges, but the native portal rule restricts res.partner to
+         child_of commercial_partner_id, which blocks that read.
+         This rule grants the minimum extra access: only the company partners. -->
+    <record id="portal_res_partner_company_rule" model="ir.rule">
+        <field name="name">Portal Distributor: read own company partners</field>
+        <field name="model_id" ref="base.model_res_partner"/>
+        <field name="domain_force">[('id', 'in', user.company_ids.partner_id.ids)]</field>
+        <field name="groups" eval="[(4, ref('group_portal_backend_distributor'))]"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="0" name="perm_create"/>
+        <field eval="0" name="perm_unlink"/>
+    </record>
+
 </odoo>

--- a/portal_sale_distributor_event/__manifest__.py
+++ b/portal_sale_distributor_event/__manifest__.py
@@ -26,7 +26,7 @@
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",
     "depends": [
-        "event",
+        "event_sale",
         "portal_sale_distributor",
     ],
     "demo": [],


### PR DESCRIPTION
…ead company partners

Portal distributor users were unable to create sale orders for themselves. The sale order form reads company_id.partner_id during rendering and onchanges, but the native portal rule restricts res.partner access to child_of commercial_partner_id, blocking that read with an AccessError.

Add a minimal ir.rule granting the group read-only access to the Odoo company partner(s) the user belongs to — no access to customers, suppliers or any other partner.