### PR TITLE
[FIX] sale_stock_product_pack_ux: recompute quantity_returned on component return

### DIFF
--- a/sale_stock_product_pack_ux/models/sale_order_line.py
+++ b/sale_stock_product_pack_ux/models/sale_order_line.py
@@ -1,9 +1,16 @@
-from odoo import models
+from odoo import api, models
 
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
+    @api.depends(
+        "pack_child_line_ids.qty_delivered_method",
+        "pack_child_line_ids.move_ids.state",
+        "pack_child_line_ids.move_ids.scrap_id",
+        "pack_child_line_ids.move_ids.product_uom_qty",
+        "pack_child_line_ids.move_ids.product_uom",
+    )
     def _compute_quantity_returned(self):
         res = super()._compute_quantity_returned()
 

--- a/sale_stock_product_pack_ux/tests/__init__.py
+++ b/sale_stock_product_pack_ux/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_stock_product_pack_ux

--- a/sale_stock_product_pack_ux/tests/test_sale_stock_product_pack_ux.py
+++ b/sale_stock_product_pack_ux/tests/test_sale_stock_product_pack_ux.py
@@ -1,0 +1,80 @@
+from odoo.addons.sale_product_pack.tests.common import TestSaleProductPackBase
+
+
+class TestSaleStockProductPackUx(TestSaleProductPackBase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.pack.type = "consu"
+        cls.component1.is_storable = True
+        cls.component2.is_storable = True
+        cls.warehouse = cls.env["stock.warehouse"].search([("company_id", "=", cls.env.company.id)], limit=1)
+        # One-step delivery: the test assumes a single outgoing picking.
+        cls.warehouse.delivery_steps = "ship_only"
+        cls.env["stock.quant"]._update_available_quantity(cls.component1, cls.warehouse.lot_stock_id, 20)
+        cls.env["stock.quant"]._update_available_quantity(cls.component2, cls.warehouse.lot_stock_id, 20)
+
+    def _create_return_moves(self, delivery_moves, qty_by_product):
+        # Return moves built by hand: the wizard depends on the warehouse route.
+        return_picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": delivery_moves[:1].picking_id.picking_type_id.id,
+                "location_id": delivery_moves[:1].location_dest_id.id,
+                "location_dest_id": delivery_moves[:1].location_id.id,
+            }
+        )
+        for move in delivery_moves:
+            qty = qty_by_product.get(move.product_id, 0.0)
+            if not qty:
+                continue
+            self.env["stock.move"].create(
+                {
+                    "product_id": move.product_id.id,
+                    "product_uom_qty": qty,
+                    "quantity": qty,
+                    "product_uom": move.product_uom.id,
+                    "picking_id": return_picking.id,
+                    "location_id": move.location_dest_id.id,
+                    "location_dest_id": move.location_id.id,
+                    "sale_line_id": move.sale_line_id.id,
+                    "origin_returned_move_id": move.id,
+                    "to_refund": True,
+                    "state": "done",
+                    "picked": True,
+                }
+            )
+        return return_picking
+
+    def test_quantity_returned_pack_after_component_return(self):
+        """Returning a pack's components must update the pack line's own
+        'quantity_returned', with no forced recompute."""
+        pack_line = self._add_so_line()
+        pack_line.product_uom_qty = 2
+        sale = self.sale_order
+        # sale_exception can turn action_confirm() into a no-op.
+        if "ignore_exception" in sale._fields:
+            sale.ignore_exception = True
+        sale.action_confirm()
+        self.assertEqual(sale.state, "sale", "action_confirm did not confirm the order.")
+        picking = sale.picking_ids
+        for move in picking.move_ids:
+            move.quantity = move.product_uom_qty
+        picking.move_ids.picked = True
+        picking.button_validate()
+        self.assertEqual(
+            picking.state,
+            "done",
+            "Delivery picking did not complete (button_validate likely "
+            "returned a wizard action instead of validating directly).",
+        )
+
+        self.assertEqual(pack_line.quantity_returned, 0.0)
+
+        # Return exactly 1 pack's worth of both components (proportional).
+        delivery_moves = picking.move_ids.filtered(lambda m: m.state == "done")
+        self.assertTrue(delivery_moves, "No completed delivery moves found to return.")
+        self._create_return_moves(delivery_moves, {self.component1: 2.0, self.component2: 1.0})
+
+        # No explicit invalidate/recompute call here: this must reflect the
+        # return through normal field dependency tracking alone.
+        self.assertEqual(pack_line.quantity_returned, 1.0)


### PR DESCRIPTION
## Problema

`_compute_quantity_returned` (en `sale_stock_product_pack_ux`) deriva el `quantity_returned` de la línea del pack a partir de sus componentes (`pack_child_line_ids`), igual que `sale_stock_product_pack` hace con `qty_delivered`. Pero solo dependía de los `stock.move` **propios** de la línea del pack — que en una devolución de componentes no se tocan.

Resultado: al devolver los componentes de un pack, la **Cantidad devuelta** de la línea del pack quedaba desactualizada (en 0.00), aunque las líneas de los componentes sí mostraran su devolución. Eso deja `all_qty_delivered` (`qty_delivered + quantity_returned`) inconsistente con lo pedido, y afecta el estado de entrega y facturación de la línea.

## Cambio

`sale_stock_product_pack_ux/models/sale_order_line.py`: se agrega `@api.depends` sobre los stock moves de los componentes — los mismos depends que `sale_stock_ux` declara para `quantity_returned`, un salto más allá a través de `pack_child_line_ids`.

## Companion

Este PR cubre `quantity_returned`, que es un campo propio de `sale_stock_ux` y no existe en OCA.

El campo estándar `qty_delivered` tiene el bug análogo, con la misma causa raíz, y se corrige en [OCA/product-pack#262](https://github.com/OCA/product-pack/pull/262) (ya incluido en la imagen de Adhoc-CICD). **Los dos son necesarios**: con este PR solo, la cadena de delivery status no cierra.

## Sobre los tests

Se agrega cobertura al módulo, que no tenía ninguna.

Dos decisiones de implementación que vale explicar:

1. **Los moves de devolución se arman por ORM y no con el wizard `stock.return.picking`.** Esa orquestación depende de la ruta de salida del depósito (uno o varios pasos) y de overrides de enterprise — en particular `helpdesk_stock`, que redeclara el `picking_id` del wizard como campo computado con lógica de resolución propia, capaz de sobrescribir el picking que el test quiere devolver incluso pasándolo explícito en el `create`. Armarlos a mano hace el test determinístico y replica exactamente los campos que mira el filtro de `_compute_quantity_returned`.

2. **El `setUpClass` fija `delivery_steps = "ship_only"`.** El test asume un único albarán de salida; sin fijarlo, hereda la configuración del depósito de la base donde corra y falla por ambiente si el depósito entrega en dos o tres pasos. Verificado: forzando `pick_ship`, el test falla.

3. **Se fuerza `ignore_exception`** antes de confirmar, porque `sale_exception` puede convertir `action_confirm()` en un no-op silencioso (devuelve la acción del popup en vez de confirmar) según las reglas de excepción configuradas.

## Test plan

- Nuevo test `test_quantity_returned_pack_after_component_return`: vende 2 packs, entrega, devuelve el equivalente a 1 pack completo (proporcional en ambos componentes) y verifica que `quantity_returned` de la línea del pack pase a 1.00 **sin** ningún recompute manual.
- Verificado que el test falla contra el código anterior al fix.
- Suites completas de `product_pack` / `sale_product_pack` / `stock_product_pack` / `sale_stock_product_pack` / `sale_stock_ux` / `sale_stock_product_pack_ux`: **39 tests, 0 fallas**.
- Validado además end-to-end desde la UI en una base con ambos PRs aplicados: entrega proporcional (0 → 1.00 → 2.00) y devolución (Entregado 2→1, Devuelta 0→1).