### PR TITLE
[FIX] sale_stock_ux: use product_uom_id in _get_qty_procurement for exchange moves

### DIFF
--- a/sale_stock_ux/models/sale_order_line.py
+++ b/sale_stock_ux/models/sale_order_line.py
@@ -79,10 +79,10 @@ class SaleOrderLine(models.Model):
         outgoing_moves, incoming_moves = self._get_outgoing_incoming_moves(strict=False)
         for move in outgoing_moves.filtered(lambda m: m.is_exchange_move):
             qty_to_compute = move.quantity if move.state == "done" else move.product_uom_qty
-            qty -= move.product_uom._compute_quantity(qty_to_compute, self.product_uom, rounding_method="HALF-UP")
+            qty -= move.product_uom._compute_quantity(qty_to_compute, self.product_uom_id, rounding_method="HALF-UP")
         for move in incoming_moves.filtered(lambda m: m.is_exchange_move):
             qty_to_compute = move.quantity if move.state == "done" else move.product_uom_qty
-            qty += move.product_uom._compute_quantity(qty_to_compute, self.product_uom, rounding_method="HALF-UP")
+            qty += move.product_uom._compute_quantity(qty_to_compute, self.product_uom_id, rounding_method="HALF-UP")
         return qty
 
     @api.depends()


### PR DESCRIPTION
## Problem

Increasing the ordered quantity of a sale order line that has an active "exchange" return (`is_exchange_move`) raises:

```
AttributeError: 'sale.order.line' object has no attribute 'product_uom'
```

in `sale_stock_ux/models/sale_order_line.py`, method `_get_qty_procurement`.

## Root cause

`sale.order.line.product_uom` was renamed to `product_uom_id` in a previous migration (see `17d0b8e`), which updated most of this file but missed the two occurrences inside `_get_qty_procurement`. `stock.move.product_uom` is unaffected and still exists as-is.

## Fix

Replace `self.product_uom` with `self.product_uom_id` in the two affected lines. No behavior change beyond fixing the crash — same UoM conversion logic as the rest of the file.

## Test plan

- Confirm a sale order and deliver it.
- Create an exchange return (`stock.return.picking.action_create_exchanges`) on one of the lines and validate it.
- Increase the ordered quantity on that line and save.
- Expected: saves without traceback (previously: `AttributeError`).