### PR TITLE
[FIX] sale_order_type_invoice_policy: detect delivery chain via routing rules when the next leg is not created yet

### DIFF
--- a/sale_order_type_invoice_policy/models/stock_picking.py
+++ b/sale_order_type_invoice_policy/models/stock_picking.py
@@ -72,8 +72,42 @@ class StockPicking(models.Model):
         cover the default 3-step route and miss any extra custom ones.
         Return/receipt pickings are excluded naturally, since their moves
         never end up in a customer location.
+
+        Some routes only create the next leg's stock.move once the current
+        one is done (instead of upfront at sale confirmation), so rolling up
+        move_dest_ids alone misses the chain for pickings validated before
+        that next move exists. Falling back to the warehouse's stock.rule
+        graph covers that case: rules are static routing configuration, so
+        they are already there even when the moves they will generate are
+        not.
+
+        The rule graph is direction-blind though: a return leg can land on
+        an internal location (e.g. the warehouse's own Stock) from which
+        outgoing rules for future sales are still reachable, which would
+        wrongly read as "heading to a customer". Returned moves are excluded
+        upfront (via move_orig_ids rollup, so a later leg of a multi-step
+        return is also caught) before even considering that fallback.
         """
         self.ensure_one()
         moves = self.move_ids
+        orig_moves = moves.browse(moves._rollup_move_origs())
+        if orig_moves.filtered("origin_returned_move_id"):
+            return False
+
         dest_moves = moves.browse(moves._rollup_move_dests())
-        return bool((moves | dest_moves).filtered(lambda m: m.location_dest_id.usage == "customer"))
+        if (moves | dest_moves).filtered(lambda m: m.location_dest_id.usage == "customer"):
+            return True
+
+        Rule = self.env["stock.rule"]
+        to_visit = set(moves.location_dest_id.ids)
+        seen = set()
+        while to_visit:
+            location_id = to_visit.pop()
+            if location_id in seen:
+                continue
+            seen.add(location_id)
+            if self.env["stock.location"].browse(location_id).usage == "customer":
+                return True
+            next_rules = Rule.search([("location_src_id", "=", location_id), ("active", "=", True)])
+            to_visit.update(set(next_rules.location_dest_id.ids) - seen)
+        return False


### PR DESCRIPTION
## Summary

`_is_delivery_chain()` (introduced in #1765) determines whether a picking eventually reaches a customer location by rolling up already-created `stock.move` records via `move_dest_ids`. On routes where the next leg's move is generated lazily — only once the current leg is marked done, instead of upfront at sale confirmation — that rollup finds nothing yet at `button_validate()` time. The prepaid / `prepaid_block_delivery` check in `button_validate()` is then silently skipped on the first leg of any multi-step delivery, which is exactly the leg where stock physically leaves the warehouse.

## Fix

Falls back to walking the warehouse's `stock.rule` graph (`location_src_id` -> `location_dest_id` per active rule) starting from each move's current destination, when the move-based rollup finds no customer location. Rules are static routing configuration and exist regardless of whether the moves they will generate have been created yet.

## Test plan

- Warehouse with a 2+ step delivery route where the next leg's `stock.move` is only created once the current leg is validated (not upfront at confirmation). Confirm a sale order with type `invoice_policy=prepaid`/`prepaid_block_delivery` and an unpaid invoice, then validate the first leg (e.g. Pick): `button_validate()` should now raise the `UserError` instead of going through.
- Regression: standard 3-step delivery (Pick/Pack/Out) where all moves are created upfront still blocks as before (covered by the existing move-based rollup).
- Regression: receipts/returns are not blocked (their rule graph never reaches a customer location).

Ref: ticket 123212.