### PR TITLE
[FIX] sale_stock_ux: skip returned qty deduction in stock.move.create…

### DIFF
--- a/sale_stock_ux/models/stock_move.py
+++ b/sale_stock_ux/models/stock_move.py
@@ -39,8 +39,13 @@ class StockMove(models.Model):
                 and not vals.get("is_exchange_move")
                 and not vals.get("origin_returned_move_id")
             ):
-                sale_line_qty_ret = self.env["sale.order.line"].browse(vals["sale_line_id"]).quantity_returned
-                vals["product_uom_qty"] -= sale_line_qty_ret
+                sale_line = self.env["sale.order.line"].browse(vals["sale_line_id"])
+                # Para suscripciones NO restar quantity_returned: ya esta contemplado en
+                # qty_delivered y en sale_order_line._create_procurements. Restarlo tambien aca
+                # lo cuenta dos veces y deja el movimiento en cero (o negativo -> invierte el
+                # picking a IN). Mismo criterio que _create_procurements.
+                if not sale_line._check_is_recurring_invoice():
+                    vals["product_uom_qty"] -= sale_line.quantity_returned
                 if "secondary_uom_qty" in vals:
                     del vals["secondary_uom_qty"]
 


### PR DESCRIPTION
… for subscriptions

PR #1667 added the recurring-invoice guard to
SaleOrderLine._create_procurements so subscription procurements no longer subtract quantity_returned. But StockMove.create still subtracted quantity_returned unconditionally for any move with a sale_line_id.

For a subscription line whose delivery was returned, the deduction was therefore applied twice (procurement already accounts the return in qty_delivered), so the next period's delivery was created with demand 0 (or negative, which flips the picking to a receipt/IN).

Apply the same _check_is_recurring_invoice() guard in StockMove.create: skip the quantity_returned deduction for subscription lines, keep it for regular sale orders. The guard lives in sale_stock_ux and is defensive (_fields.get), so it is safe when sale_subscription is not installed.