### PR TITLE
[FIX] sale_stock_ux: avoid double deduction of returned qty on delivery

### DIFF
--- a/sale_stock_ux/models/stock_move.py
+++ b/sale_stock_ux/models/stock_move.py
@@ -21,29 +21,22 @@ class StockMove(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        """La cantidad devuelta no deberia ser contada en los nuevos movimientos de
-        entrega genuinos que se creen a partir de una orden de venta.
-        Agregamos un HACK para que si esta instalado secondary unit sea recomputada en la creacion de
-        movimientos de stock.
+        """HACK para que, si está instalado secondary unit, se recompute la
+        unidad secundaria en la creación de movimientos de stock a partir de una
+        orden de venta (borramos ``secondary_uom_qty`` para que se recalcule
+        desde ``product_uom_qty``).
 
-        Solo debe impactar en entregas genuinas: NO en los movimientos de
-        devolucion (``origin_returned_move_id``) ni en los de devolucion para
-        cambio (``is_exchange_move``). Esos ajustan la demanda por otra via y, si
-        se les resta ``quantity_returned``, nacen con la demanda corrupta -- por
-        ejemplo, una 2da devolucion o un cambio sobre una OV con una devolucion
-        previa con reembolso quedaban con demanda = cantidad - quantity_returned.
+        La cantidad devuelta (``quantity_returned``) NO se resta acá: eso lo hace
+        ``sale.order.line._create_procurements`` (que además excluye
+        suscripciones vía ``_check_is_recurring_invoice``). Restarla también acá
+        duplicaba el descuento y, al subir la cantidad pedida luego de una
+        devolución total, dejaba la demanda en negativo -> Odoo invertía el
+        movimiento y creaba una recepción (IN) en lugar de una entrega (OUT).
+        Mismo criterio que 18.0, donde esta resta está deshabilitada.
         """
         for vals in vals_list:
-            if (
-                vals.get("sale_line_id")
-                and not vals.get("is_exchange_move")
-                and not vals.get("origin_returned_move_id")
-            ):
-                sale_line_qty_ret = self.env["sale.order.line"].browse(vals["sale_line_id"]).quantity_returned
-                vals["product_uom_qty"] -= sale_line_qty_ret
-                if "secondary_uom_qty" in vals:
-                    del vals["secondary_uom_qty"]
-
+            if vals.get("sale_line_id") and vals.get("secondary_uom_qty"):
+                del vals["secondary_uom_qty"]
         return super().create(vals_list)
 
     def _get_new_picking_values(self):


### PR DESCRIPTION
## Problema

Al **incrementar la cantidad pedida después de una devolución total con reembolso** se generaba un movimiento **entrante (IN)** en lugar de una **entrega (OUT)**, y por una cantidad errónea.

Ejemplo: vender 5 → entregar 5 → devolver 5 (con reembolso) → subir la cantidad a 6.
Esperado: entrega (OUT) por 1. Obtenido: recepción (IN) por 4.

## Causa

`quantity_returned` se restaba **dos veces** sobre la misma entrega genuina:

1. `SaleOrderLine._create_procurements()` → `product_qty -= self.quantity_returned` (agregado en #1671 para excluir suscripciones).
2. `StockMove.create()` → `vals['product_uom_qty'] -= quantity_returned`.

Con `qty_procurement = 0`: `6 − 5 − 5 = −4`. La demanda negativa hace que Odoo invierta el movimiento y lo cree como recepción (IN) por 4.

En **18.0** la resta dentro de `StockMove.create` está **comentada** justamente por esto; la única resta vive en `_create_procurements`. En la migración a 19.0 quedó activa además de `_create_procurements`, produciendo la doble resta.

## Solución

Se quita **solo** la resta de `quantity_returned` de `StockMove.create`, **manteniendo** el reset de `secondary_uom_qty` (unidad secundaria). `_create_procurements` queda como única fuente del descuento (ya excluye suscripciones vía `_check_is_recurring_invoice`). Alinea 19.0 con el comportamiento de 18.0.

Las devoluciones y las **devoluciones para cambio** (`is_exchange_move` / `action_create_exchanges`) no pasan por `_create_procurements`, por lo que no se ven afectadas (antes las protegía el guard del `create`; al no restar, la protección es automática).

## Verificación

- Flujo del ticket: al subir la cantidad tras devolución total se genera una entrega (OUT) por la diferencia.
- Suite `sale_stock_ux` en verde, incluida `test_return_exchange_demand` (2da devolución y devolución con cambio, regresión del ticket 120871).

Ticket: 123179