### PR TITLE
[FIX] sale_gathering: keep manual discount on order confirmation

### DIFF
--- a/sale_gathering/models/sale_order_line.py
+++ b/sale_gathering/models/sale_order_line.py
@@ -13,6 +13,10 @@ class SaleOrderLine(models.Model):
         gathering_lines = self.filtered(lambda x: x.is_gathering and x.initial_qty_gathered > 0)
         super(SaleOrderLine, self - gathering_lines)._compute_price_unit()
 
+    def _compute_discount(self):
+        gathering_lines = self.filtered(lambda x: x.is_gathering and x.initial_qty_gathered > 0)
+        super(SaleOrderLine, self - gathering_lines)._compute_discount()
+
     def _prepare_base_line_for_taxes_computation(self, **kwargs):
         self.ensure_one()
         if self.initial_qty_gathered > 0 and self.env.context.get("first_gathering_invoice"):


### PR DESCRIPTION
On gathering orders, _action_confirm moves each line quantity to initial_qty_gathered and writes product_uom_qty = 0. Since discount is a stored computed field depending on product_uom_qty, that write retriggered _compute_discount, which reset the manual discount from the pricelist (e.g. to 0% with a percentage rule).

Protect gathering lines with initial_qty_gathered > 0 from the discount recompute, mirroring the existing _compute_price_unit override.