### PR TITLE
[FIX] sale_stock_ux: skip kit component moves in quantity_returned

### DIFF
--- a/sale_stock_ux/models/sale_order_line.py
+++ b/sale_stock_ux/models/sale_order_line.py
@@ -202,6 +202,7 @@ class SaleOrderLine(models.Model):
         "move_ids.product_uom",
     )
     def _compute_quantity_returned(self):
+        bom_enable = "bom_ids" in self.env["product.template"]._fields
         for order_line in self:
             quantity_returned = 0.0
             # we use same method as in odoo use to delivery's
@@ -217,12 +218,16 @@ class SaleOrderLine(models.Model):
                         and r.to_refund
                     )
                 )
-                # In multi-step deliveries, we need to avoid counting the same return multiple times
-                for move in return_moves.filtered(lambda m: m.location_id.usage == "customer"):
+                # Kit component moves are skipped here: their returned quantity is computed
+                # below by _compute_kit_quantities, and their UoM may belong to a different
+                # category than the order line's.
+                non_kit_moves = return_moves
+                if bom_enable:
+                    non_kit_moves = return_moves.filtered(lambda m: m.bom_line_id.bom_id.type != "phantom")
+                for move in non_kit_moves:
                     quantity_returned += move.product_uom._compute_quantity(
                         move.product_uom_qty, order_line.product_uom
                     )
-                bom_enable = "bom_ids" in self.env["product.template"]._fields
                 if bom_enable:
                     boms = return_moves.mapped("bom_line_id.bom_id")
                     dropship = False

--- a/sale_stock_ux/tests/__init__.py
+++ b/sale_stock_ux/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_action_cancel
+from . import test_kit_return_uom
 from . import test_return_of_return

--- a/sale_stock_ux/tests/test_kit_return_uom.py
+++ b/sale_stock_ux/tests/test_kit_return_uom.py
@@ -1,0 +1,135 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestKitReturnUom(TransactionCase):
+    """Devolver un kit cuyos componentes están en otra categoría de UdM no debe romper.
+
+    Un kit (BoM phantom) vendido en unidades con su componente en litros explota
+    en movimientos de stock en litros. Al validar la devolución se convertía la
+    UdM del movimiento a la de la línea y, al ser categorías distintas, el
+    `_compute_quantity` nativo de `uom` levantaba UserError. Para kits ese valor
+    lo pisa después `_compute_kit_quantities`, así que la conversión nunca hizo
+    falta. Ver ticket 123147.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # El escenario necesita sale_mrp: mrp explota el kit, pero el cálculo de
+        # cantidades entregadas/devueltas de kits lo aporta sale_mrp.
+        if not self.env["ir.module.module"].search_count([("name", "=", "sale_mrp"), ("state", "=", "installed")]):
+            self.skipTest("sale_mrp no está instalado")
+
+        warehouse = self.env["stock.warehouse"].search([("company_id", "=", self.env.company.id)], limit=1)
+        warehouse.delivery_steps = "ship_only"
+
+        self.partner = self.env["res.partner"].create({"name": "Test Partner Kit", "customer_rank": 1})
+
+        self.uom_unit = self.env.ref("uom.product_uom_unit")
+        self.uom_litre = self.env.ref("uom.product_uom_litre")
+
+        self.component = self.env["product.product"].create(
+            {
+                "name": "Esencia (litros)",
+                "type": "consu",
+                "is_storable": True,
+                "uom_id": self.uom_litre.id,
+                "uom_po_id": self.uom_litre.id,
+                "list_price": 50.0,
+            }
+        )
+        self.kit = self.env["product.product"].create(
+            {
+                "name": "Carga fragancia (kit en unidades)",
+                "type": "consu",
+                "is_storable": True,
+                "uom_id": self.uom_unit.id,
+                "uom_po_id": self.uom_unit.id,
+                "invoice_policy": "delivery",
+                "list_price": 100.0,
+            }
+        )
+        self.env["mrp.bom"].create(
+            {
+                "product_tmpl_id": self.kit.product_tmpl_id.id,
+                "product_id": self.kit.id,
+                "product_qty": 1.0,
+                "product_uom_id": self.uom_unit.id,
+                "type": "phantom",
+                "bom_line_ids": [
+                    (0, 0, {"product_id": self.component.id, "product_qty": 0.15, "product_uom_id": self.uom_litre.id})
+                ],
+            }
+        )
+
+        if self.env["sale.order"]._fields.get("ignore_exception"):
+            self.env["exception.rule"].search([("active", "=", True)]).write({"active": False})
+
+        self.sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "warehouse_id": warehouse.id,
+                "order_line": [(0, 0, {"product_id": self.kit.id, "product_uom_qty": 1.0, "price_unit": 100.0})],
+            }
+        )
+        self.sale_order.action_confirm()
+        self.order_line = self.sale_order.order_line
+        self.delivery = self.sale_order.picking_ids
+
+    def _validate(self, picking):
+        picking.action_confirm()
+        picking.action_assign()
+        for move in picking.move_ids:
+            move.move_line_ids.unlink()
+            move.quantity = move.product_uom_qty
+            move.picked = True
+        picking._action_done()
+
+    def _make_return(self, picking, to_refund=True):
+        wizard = (
+            self.env["stock.return.picking"]
+            .with_context(active_id=picking.id, active_ids=picking.ids, active_model="stock.picking")
+            .create({})
+        )
+        for line in wizard.product_return_moves:
+            line.to_refund = to_refund
+            line.quantity = line.move_id.quantity
+        action = wizard.action_create_returns()
+        return self.env["stock.picking"].browse(action["res_id"])
+
+    def test_delivery_of_kit_explodes_into_component_uom(self):
+        """El kit se explota en movimientos del componente, en litros."""
+        self.assertEqual(self.delivery.move_ids.product_id, self.component)
+        self.assertEqual(self.delivery.move_ids.product_uom, self.uom_litre)
+        self._validate(self.delivery)
+        self.assertEqual(self.delivery.state, "done")
+        self.assertEqual(self.order_line.qty_delivered, 1.0)
+        self.assertEqual(self.order_line.quantity_returned, 0.0)
+
+    def test_return_of_kit_with_component_in_other_uom_category(self):
+        """Validar la devolución no debe levantar UserError por conversión de UdM."""
+        # Precondición del caso: el componente vive en otra categoría que el kit.
+        self.assertNotEqual(self.uom_unit.category_id, self.uom_litre.category_id)
+        self._validate(self.delivery)
+
+        returned = self._make_return(self.delivery, to_refund=True)
+        self.assertEqual(returned.move_ids.product_uom, self.uom_litre)
+
+        # Sin el fix, esto levanta UserError desde uom._compute_quantity
+        # (Unidades y Litros no comparten categoría).
+        self._validate(returned)
+
+        self.assertEqual(returned.state, "done")
+        # La cantidad devuelta la calcula _compute_kit_quantities en unidades del kit.
+        self.assertEqual(self.order_line.quantity_returned, 1.0)
+        self.assertEqual(self.order_line.qty_delivered, 0.0)
+
+    def test_return_of_kit_without_refund(self):
+        """Sin 'actualizar cantidades a facturar' tampoco rompe y no descuenta."""
+        self._validate(self.delivery)
+
+        returned = self._make_return(self.delivery, to_refund=False)
+        self._validate(returned)
+
+        self.assertEqual(returned.state, "done")
+        self.assertEqual(self.order_line.quantity_returned, 0.0)


### PR DESCRIPTION
## Problema

Validar la **devolución** de un kit (LdM phantom) cuyos componentes usan una UdM de otra categoría que la línea de venta levanta un `UserError` y el usuario no puede completar el ingreso. Caso típico: kit vendido en Unidades con un componente medido en Litros.

La entrega funciona sin problema; el error es puntual de la devolución.

## Causa

El primer loop de `_compute_quantity_returned` convierte la UdM de cada movimiento de devolución a la de la línea de la orden:

```python
quantity_returned += move.product_uom._compute_quantity(move.product_uom_qty, order_line.product_uom)
```

Para un kit, los movimientos de stock son los **componentes**, así que ahí se intenta convertir (por ejemplo) Litros → Unidades. El `uom._compute_quantity` nativo rechaza conversiones entre categorías distintas y levanta `UserError`. El compute depende de `move_ids.state`, por eso salta al validar.

Ese valor acumulado **se descarta unas líneas más abajo** para kits: lo pisa `_compute_kit_quantities`. La conversión nunca hizo falta.

## Solución

Saltear los movimientos de componentes de kit en ese primer loop, dejando que `_compute_kit_quantities` haga el cálculo. Se descartó pasar `raise_if_failure=False` porque devuelve la cantidad **sin convertir**, dejando un número incorrecto latente.

De paso se saca un `.filtered(...)` redundante: `return_moves` ya exige `location_id.usage == "customer"` en su propio filtro.