### PR TITLE
[FIX] sale_ux: avoid spurious credit note on fully deducted final invoice

### DIFF
--- a/sale_ux/models/account_move.py
+++ b/sale_ux/models/account_move.py
@@ -12,6 +12,16 @@ class AccountMove(models.Model):
     sale_order_ids = fields.Many2many("sale.order", compute="_compute_sale_orders")
     # en la ui agregamos este que seria mejor a nivel performance
     has_sales = fields.Boolean(string="Has Sales?", compute="_compute_has_sales")
+    # no almacenado: solo memoiza el chequeo por factura para no recorrer las lineas una
+    # vez por linea en _prepare_product_base_line_for_taxes_computation (ver ahi)
+    has_downpayment_deduction = fields.Boolean(compute="_compute_has_downpayment_deduction")
+
+    @api.depends("invoice_line_ids.is_downpayment", "invoice_line_ids.display_type")
+    def _compute_has_downpayment_deduction(self):
+        for move in self:
+            move.has_downpayment_deduction = any(
+                line.is_downpayment for line in move.invoice_line_ids if line.display_type == "product"
+            )
 
     @api.depends("move_type", "partner_id", "partner_id.lang", "company_id")
     def _compute_narration(self):
@@ -38,6 +48,26 @@ class AccountMove(models.Model):
         (self - moves).has_sales = False
         for rec in moves:
             rec.has_sales = any(line for line in rec.invoice_line_ids.mapped("sale_line_ids"))
+
+    # Evaluar en proximas verciones si Odoo lo resuelve
+    # Propuesto upstream en https://github.com/odoo/odoo/pull/278963
+    def _prepare_product_base_line_for_taxes_computation(self, product_line):
+        base_line = super()._prepare_product_base_line_for_taxes_computation(product_line)
+        # El wizard de anticipos redondea a la moneda el price_unit del anticipo
+        # (_prepare_down_payment_lines_values), asi que no cancela exacto contra las lineas
+        # que dedujo cuando el subtotal crudo de alguna cae en medio centavo. Con
+        # round_globally ese residuo se amplifica a un centavo entero que aterriza en la
+        # linea base mas grande, y puede dar vuelta la factura final a nota de credito.
+        # Apuntamos a los importes ya redondeados (price_subtotal), que son los que se
+        # facturaron en el anticipo, para que la agregacion cancele exacto.
+        if (
+            base_line.get("special_type") != "down_payment"
+            and self.is_invoice(include_receipts=True)
+            and self.company_id.tax_calculation_rounding_method == "round_globally"
+            and self.has_downpayment_deduction
+        ):
+            base_line["manual_total_excluded_currency"] = product_line.price_subtotal
+        return base_line
 
     # Evaluar en proximas verciones si Odoo lo resuelve
     def action_post(self):

--- a/sale_ux/tests/__init__.py
+++ b/sale_ux/tests/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import test_downpayment_rounding

--- a/sale_ux/tests/test_downpayment_rounding.py
+++ b/sale_ux/tests/test_downpayment_rounding.py
@@ -1,0 +1,47 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestDownpaymentRounding(AccountTestInvoicingCommon):
+    def test_full_downpayment_half_cent_residual_final_invoice(self):
+        """A 100% down payment must leave a zero final invoice, not a 0.01 credit note.
+
+        With round_globally, qty 0.5 at price_unit 1.01 has a raw subtotal of 0.505,
+        while the down payment line can only store the rounded 0.51. That -0.005 residual
+        used to be amplified into a full cent, flipping the final invoice into a refund.
+        """
+        # sale_exception (via demo data) trae reglas activas que hacen que action_confirm
+        # devuelva un popup sin confirmar la orden (queda en 'draft' y no habria nada que
+        # facturar). Las desactivamos para que el escenario sea determinista.
+        if "exception.rule" in self.env:
+            self.env["exception.rule"].sudo().search([]).write({"active": False})
+        self.env.company.tax_calculation_rounding_method = "round_globally"
+        # Producto consumible facturado por orden, como el 'product_order_no' que usa el
+        # core para sus tests de anticipos: 'consu' + invoice_policy 'order' es lo mas
+        # robusto en el stack completo de runbot (un 'service' arrastra service_policy /
+        # subscription / timesheet que pueden dejar la factura final sin items facturables).
+        # _create_product setea las cuentas de ingreso/gasto; taxes_id vacio para que el
+        # subtotal crudo caiga justo en el medio centavo.
+        product = self._create_product(name="DP rounding", type="consu", invoice_policy="order", taxes_id=[])
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "order_line": [(0, 0, {"product_id": product.id, "product_uom_qty": 0.5, "price_unit": 1.01})],
+            }
+        )
+        order.action_confirm()
+
+        self.env["sale.advance.payment.inv"].with_context(
+            active_model="sale.order", active_ids=order.ids, active_id=order.id
+        ).create({"advance_payment_method": "percentage", "amount": 100}).create_invoices()
+        order.invoice_ids.action_post()
+
+        final_invoice = order._create_invoices(final=True)
+
+        self.assertEqual(final_invoice.move_type, "out_invoice")
+        self.assertEqual(final_invoice.amount_total, 0.0)


### PR DESCRIPTION
With "Round Globally" tax rounding, invoicing a 100% down payment and then creating the final regular invoice yields a credit note of 0.01 instead of an invoice of 0.00. The sales order is still flagged as fully invoiced, so the customer is left with an unexpected refund document, and cancelling it with a debit note duplicates the quantities.

A down payment line can only store a `price_unit` rounded to the 'Product Price' decimal precision, while the product lines it must offset are aggregated from their raw amounts. When a product subtotal falls on a half cent (e.g. quantity 0.5 at 1.01 => 0.505), the final invoice carries a raw residual of -0.005. `_round_tax_details_base_lines` rounds that aggregate to -0.01 and `_distribute_delta_amount_smoothly` assigns the cent to the largest base line, leaving its `balance` one cent away from its o
`amount_untaxed` derives from the balances, the invoice totals -0.01 and `_create_invoices` switches it to a refund.

The product amounts have already been invoicedent
invoice, so the aggregation must target those rounded amounts. Declare them through `manual_total_excluded_currency`, whicdict and feeds `target_total_excluded`. `total_excluded` is unchanged, so no posted or displayed amount moves.