### PR TITLE
[FIX] portal_sale_distributor: allow the distributor group to read warehouses

### DIFF
--- a/portal_sale_distributor/security/portal_sale_distributor_security.xml
+++ b/portal_sale_distributor/security/portal_sale_distributor_security.xml
@@ -51,15 +51,26 @@
         <field eval="0" name="perm_unlink"/>
     </record>
 
-    <!-- The ir.model.access above grants read on stock.warehouse, but a portal
-         user is also in base.group_portal, and mrp_subcontracting adds a rule
-         on that group restricting warehouses to the ones of the partner's own
-         pickings. A distributor placing its first order has none, so adding a
-         sale order line fails to read the warehouse. Same reason as the
-         product.template rule above. -->
+    <!-- The ir.model.access entries grant read on stock.warehouse and uom.uom,
+         but a portal user is also in base.group_portal, and mrp_subcontracting
+         adds rules on that group restricting both models to what belongs to the
+         partner's own subcontracting (its pickings, its BoMs). A distributor has
+         none of that, so it cannot add a line to a sale order. Same reason as
+         the product.template rule above. -->
     <record id="portal_stock_warehouse_rule" model="ir.rule">
         <field name="name">Warehouses (distribuidores)</field>
         <field name="model_id" ref="stock.model_stock_warehouse"/>
+        <field name="domain_force">[(1 ,'=', 1)]</field>
+        <field name="groups" eval="[(4, ref('group_portal_backend_distributor'))]"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="0" name="perm_create"/>
+        <field eval="0" name="perm_unlink"/>
+    </record>
+
+    <record id="portal_uom_rule" model="ir.rule">
+        <field name="name">UoM (distribuidores)</field>
+        <field name="model_id" ref="uom.model_uom_uom"/>
         <field name="domain_force">[(1 ,'=', 1)]</field>
         <field name="groups" eval="[(4, ref('group_portal_backend_distributor'))]"/>
         <field eval="1" name="perm_read"/>

--- a/portal_sale_distributor/security/portal_sale_distributor_security.xml
+++ b/portal_sale_distributor/security/portal_sale_distributor_security.xml
@@ -51,4 +51,21 @@
         <field eval="0" name="perm_unlink"/>
     </record>
 
+    <!-- The ir.model.access above grants read on stock.warehouse, but a portal
+         user is also in base.group_portal, and mrp_subcontracting adds a rule
+         on that group restricting warehouses to the ones of the partner's own
+         pickings. A distributor placing its first order has none, so adding a
+         sale order line fails to read the warehouse. Same reason as the
+         product.template rule above. -->
+    <record id="portal_stock_warehouse_rule" model="ir.rule">
+        <field name="name">Warehouses (distribuidores)</field>
+        <field name="model_id" ref="stock.model_stock_warehouse"/>
+        <field name="domain_force">[(1 ,'=', 1)]</field>
+        <field name="groups" eval="[(4, ref('group_portal_backend_distributor'))]"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="0" name="perm_create"/>
+        <field eval="0" name="perm_unlink"/>
+    </record>
+
 </odoo>


### PR DESCRIPTION
## Problem

`security/ir.model.access.csv` grants read on `stock.warehouse` to `group_portal_backend_distributor`, but no record rule is declared for that model. A portal user also belongs to `base.group_portal`, and `mrp_subcontracting` declares a rule on that group:

```
[('id', 'in', user.partner_id.commercial_partner_id.picking_ids.picking_type_id.warehouse_id.ids)]
```

While no portal rule existed on `stock.warehouse` the ACL alone was enough. As soon as `mrp_subcontracting` is installed, that rule applies and the distributor only sees the warehouses of its own pickings — a distributor placing its first order has none. Adding a line to a sale order then fails to read the warehouse, the row is never created, and `portal_sale_distributor_tour` times out at "wait for new row to be created".

This is not specific to the tour: any database with `portal_sale_distributor` and `mrp_subcontracting` installed has its distributor users unable to add order lines.

## Fix

A read-only rule on `stock.warehouse` for the distributor group, mirroring `portal_product_template_public_rule` right above it — that one exists for exactly the same reason, since `mrp_subcontracting` also adds a `product.template` rule on `base.group_portal`. Rules of different groups are OR-ed, so this restores the behaviour the module had before `mrp_subcontracting` was in the database, without widening what the ACL already allowed.

## Tests

Verified on a database with `portal_sale_distributor` + `mrp_subcontracting`, using a portal user in the distributor group whose partner has no pickings:

- with the rule: 1 warehouse visible
- with the rule deactivated: 0 warehouses visible, which is the state that breaks the tour

## Context

Surfaced by ingadhoc/product#921, which adds `mrp_subcontracting` to the dependency tree of `product_currency_mrp` and therefore installs it in the OBA build for the first time. Same branch name in both repos so runbot builds them together.

Internal reference: https://www.adhoc.inc/odoo/helpdesk.ticket/122531