### PR TITLE
[FIX] sale_order_type_invoice_policy: use location_final_id to detect delivery chain

### DIFF
--- a/sale_order_type_invoice_policy/models/stock_picking.py
+++ b/sale_order_type_invoice_policy/models/stock_picking.py
@@ -63,51 +63,19 @@ class StockPicking(models.Model):
         return True
 
     def _is_delivery_chain(self):
-        """Whether this picking's moves eventually reach a customer location.
+        """Whether this picking's moves ultimately reach a customer location.
 
-        Identifies pick/pack/out steps regardless of how many intermediate
-        picking types a warehouse defines (e.g. several custom Pick
-        operation types per product category), instead of relying on the
-        single warehouse.pick_type_id/pack_type_id references, which only
-        cover the default 3-step route and miss any extra custom ones.
-        Return/receipt pickings are excluded naturally, since their moves
-        never end up in a customer location.
-
-        Some routes only create the next leg's stock.move once the current
-        one is done (instead of upfront at sale confirmation), so rolling up
-        move_dest_ids alone misses the chain for pickings validated before
-        that next move exists. Falling back to the warehouse's stock.rule
-        graph covers that case: rules are static routing configuration, so
-        they are already there even when the moves they will generate are
-        not.
-
-        The rule graph is direction-blind though: a return leg can land on
-        an internal location (e.g. the warehouse's own Stock) from which
-        outgoing rules for future sales are still reachable, which would
-        wrongly read as "heading to a customer". Returned moves are excluded
-        upfront (via move_orig_ids rollup, so a later leg of a multi-step
-        return is also caught) before even considering that fallback.
+        Relies on stock.move.location_final_id, which core already computes
+        as the end of the whole chain of operations a move belongs to (set
+        from the route's rule configuration, not from moves that may not be
+        created yet). This tells apart delivery legs (pick/pack/out, whose
+        chain ends at a customer location) from receipt legs (e.g. a 2-step
+        receipt's put-away, whose chain ends in an internal location even
+        when it is tied to a sale line for MTO) and from returns (whose
+        chain does not end at a customer location either), without needing
+        to compare against specific picking types or walk routing rules by
+        hand - both of which previously misclassified pickings a warehouse
+        routes differently than the default 3-step delivery.
         """
         self.ensure_one()
-        moves = self.move_ids
-        orig_moves = moves.browse(moves._rollup_move_origs())
-        if orig_moves.filtered("origin_returned_move_id"):
-            return False
-
-        dest_moves = moves.browse(moves._rollup_move_dests())
-        if (moves | dest_moves).filtered(lambda m: m.location_dest_id.usage == "customer"):
-            return True
-
-        Rule = self.env["stock.rule"]
-        to_visit = set(moves.location_dest_id.ids)
-        seen = set()
-        while to_visit:
-            location_id = to_visit.pop()
-            if location_id in seen:
-                continue
-            seen.add(location_id)
-            if self.env["stock.location"].browse(location_id).usage == "customer":
-                return True
-            next_rules = Rule.search([("location_src_id", "=", location_id), ("active", "=", True)])
-            to_visit.update(set(next_rules.location_dest_id.ids) - seen)
-        return False
+        return bool(self.move_ids.filtered(lambda m: (m.location_final_id or m.location_dest_id).usage == "customer"))


### PR DESCRIPTION
## Problem

`_is_delivery_chain()` (used by `button_validate()` to decide whether the
prepaid invoice policy check applies to a given picking) rolled up
already-created moves and, as a fallback for routes where the next leg's
move doesn't exist yet, walked the warehouse's `stock.rule` graph by
location to guess whether a picking eventually reaches a customer.

That graph walk is **location-based, not move-specific**: starting from an
internal location, if *some* active rule anywhere in the warehouse
eventually routes to a customer location (which is normal for any
warehouse that sells from stock), the walk returns `True` — regardless of
whether the picking being validated has anything to do with that route.

This misclassified receipt-side pickings as part of the delivery chain,
including:
- The put-away step of a 2-step receipt (when it happens to be linked to
  an MTO sale line).
- The very first incoming leg of a purchase receipt.

Both got wrongly blocked when the sale order's type used the
`prepaid`/`prepaid_block_delivery` invoice policy, even though neither is
part of that order's delivery.

## Fix

`stock.move.location_final_id` already gives the true end of the chain of
operations a move belongs to — computed by core from the move's own
route/rule configuration, not from moves that may not be created yet, and
not from unrelated routes that happen to share a location.

Replaced the moves rollup + rule-graph walk + explicit return exclusion
with a single per-move check against `location_final_id` (falling back to
`location_dest_id` when not set, e.g. direct one-step moves):

```python
def _is_delivery_chain(self):
    self.ensure_one()
    return bool(
        self.move_ids.filtered(lambda m: (m.location_final_id or m.location_dest_id).usage == "customer")
    )
```

This correctly tells apart:
- **Delivery legs** (pick/pack/out, any number of custom intermediate
  picking types a warehouse defines) — chain ends at a customer location.
- **Receipt legs** (including a 2-step receipt's put-away, even when tied
  to a sale line for MTO) — chain ends at an internal location.
- **Returns** — chain does not end at a customer location either.

All without comparing against specific picking types or walking routing
rules by hand.

## Test plan

- [ ] Warehouse with 2-step reception (`reception_steps = two_steps`) and
      a sale order type using `prepaid_block_delivery`:
  - [ ] Confirm an MTO sale order that triggers a purchase order.
  - [ ] Validate the incoming receipt (step 1) → should validate OK.
  - [ ] Validate the put-away step (step 2, internal) → should validate OK.
- [ ] Warehouse with 3-step delivery (`pick_pack_ship`), same policy,
      unpaid order:
  - [ ] Validate the Pick step → should raise the prepaid error.
  - [ ] Validate the Pack step → should raise the prepaid error.
  - [ ] Pay the order fully, then validate all steps → should work.
- [ ] Warehouse with custom pick/pack picking types (not the warehouse's
      default `pick_type_id`/`pack_type_id`) → still correctly blocked
      while unpaid.
- [ ] Return of a delivered line on an unpaid order → validating the
      return should not be blocked.