### PR TITLE
[IMP] sale_order_type_invoice_policy: distinguish MTO receipt block from delivery block

### DIFF
--- a/sale_order_type_invoice_policy/i18n/es.po
+++ b/sale_order_type_invoice_policy/i18n/es.po
@@ -96,3 +96,30 @@ msgstr "No aplica la política de facturación Cantidades Entregadas para los se
 #: model:ir.model,name:sale_order_type_invoice_policy.model_sale_order_type
 msgid "Type of sale order"
 msgstr "Tipo de pedido de venta"
+
+#. module: sale_order_type_invoice_policy
+#. odoo-python
+#: code:addons/sale_order_type_invoice_policy/models/stock_picking.py:0
+msgid ""
+"If you use a sale type in the sale order related with invoice policy "
+"\"Block Reserve/Block Delivery\", then every sale line must be invoiced "
+"and paid before you can validate picking"
+msgstr ""
+"Si utiliza un tipo de pedido de venta cuya política de facturación es "
+"\"Reserva/Entrega Bloqueadas\", todas las líneas de venta deben estar "
+"facturadas y pagadas antes de poder validar la operación"
+
+#. module: sale_order_type_invoice_policy
+#. odoo-python
+#: code:addons/sale_order_type_invoice_policy/models/stock_picking.py:0
+msgid ""
+"This receipt is linked to a purchase generated to fulfill a Make To Order "
+"(MTO) sale line. Since that sale order's type uses invoice policy \"Block "
+"Reserve/Block Delivery\", the sale order must be fully invoiced and paid "
+"before you can validate this receipt."
+msgstr ""
+"Esta recepción está vinculada a una compra generada para cumplir una "
+"línea de venta bajo pedido (MTO). Como el tipo de pedido de esa venta "
+"utiliza la política de facturación \"Reserva/Entrega Bloqueadas\", la "
+"venta debe estar totalmente facturada y pagada antes de poder validar "
+"esta recepción."

--- a/sale_order_type_invoice_policy/models/stock_picking.py
+++ b/sale_order_type_invoice_policy/models/stock_picking.py
@@ -11,20 +11,27 @@ class StockPicking(models.Model):
     _inherit = "stock.picking"
 
     def button_validate(self):
-        msg = (
+        delivery_msg = (
             "If you use a sale type in the sale order related with invoice "
             'policy "Block Reserve/Block Delivery", then every sale line must '
             "be invoiced and paid before you can validate picking"
         )
-        if any(
-            self.sudo().filtered(
-                lambda x: (
-                    x._is_delivery_chain()
-                    and x.sale_id.type_id.invoice_policy in ["prepaid", "prepaid_block_delivery"]
-                    and not x._check_sale_paid()
-                )
+        mto_receipt_msg = (
+            "This receipt is linked to a purchase generated to fulfill a Make "
+            "To Order (MTO) sale line. Since that sale order's type uses "
+            'invoice policy "Block Reserve/Block Delivery", the sale order '
+            "must be fully invoiced and paid before you can validate this "
+            "receipt."
+        )
+        blocked = self.sudo().filtered(
+            lambda x: (
+                x._is_delivery_chain()
+                and x.sale_id.type_id.invoice_policy in ["prepaid", "prepaid_block_delivery"]
+                and not x._check_sale_paid()
             )
-        ):
+        )
+        if blocked:
+            msg = delivery_msg if blocked.filtered(lambda x: x._is_customer_delivery()) else mto_receipt_msg
             raise UserError(_(msg))
         return super().button_validate()
 
@@ -111,3 +118,16 @@ class StockPicking(models.Model):
             next_rules = Rule.search([("location_src_id", "=", location_id), ("active", "=", True)])
             to_visit.update(set(next_rules.location_dest_id.ids) - seen)
         return False
+
+    def _is_customer_delivery(self):
+        """Whether this picking's own moves are actually bound for a customer.
+
+        Used only to choose the error message in button_validate(): a
+        receipt tied to an unpaid MTO sale line is still blocked by
+        _is_delivery_chain() above, but it never truly ends at a customer,
+        so it gets the MTO-specific message instead of the generic delivery
+        one. stock.move.location_final_id gives the real end of this move's
+        own chain, computed by core from its route/rule configuration.
+        """
+        self.ensure_one()
+        return bool(self.move_ids.filtered(lambda m: (m.location_final_id or m.location_dest_id).usage == "customer"))


### PR DESCRIPTION
## Context

`button_validate()` blocks picking validation when the related sale order
uses the `prepaid`/`prepaid_block_delivery` invoice policy and hasn't been
fully paid. This correctly covers both:
- Outgoing deliveries to the customer.
- Receipts tied to a purchase generated to fulfill a Make To Order (MTO)
  sale line — the sale being unpaid should also hold up receiving the
  goods that will eventually fulfill it.

Both cases raised the exact same message, which only makes sense for the
delivery case ("...then every sale line must be invoiced and paid before
you can validate picking"). Users validating a receipt had no way to tell
why a purchase-side operation was being blocked by a sale order's invoice
policy.

## Change

- Added a dedicated message for the MTO-receipt case, explaining that the
  receipt exists to fulfill an MTO sale line and that the sale order needs
  to be fully invoiced and paid first.
- Added `_is_customer_delivery()`, a small helper used only to pick which
  of the two messages to show (whether this picking's own moves actually
  end at a customer location, via `stock.move.location_final_id`). The
  blocking condition itself (`_is_delivery_chain()`) is unchanged.
- Added the missing Spanish translations for both messages — they had no
  `i18n` entry at all, so Spanish-language databases were showing them in
  English.

## Test plan

- [ ] Unpaid sale order (MTO, `prepaid_block_delivery` type) generating a
      purchase order:
  - [ ] Validate the incoming receipt → blocked with the new MTO-specific
        message.
  - [ ] In a 2-step reception warehouse, validate the put-away step →
        blocked with the same MTO-specific message.
- [ ] Unpaid sale order, outgoing delivery → still blocked with the
      original delivery message.
- [ ] Both messages render in Spanish on an `es`/`es_419` database.