### PR TITLE
[IMP] sale_payment_options: discriminate payment options by sale orde…

### DIFF
--- a/sale_payment_options/README.rst
+++ b/sale_payment_options/README.rst
@@ -24,6 +24,7 @@ Allows defining and displaying multiple payment options on quotations and sales 
 - Each payment option can have multiple installment plans.
 - Payment options are shown in the sales order PDF, with tables, subtotals, and totals.
 - Handles missing or malformed data gracefully in reports.
+- Optionally, print the installment amounts per sale order line instead of the order-wide table.
 
 Installation
 ============
@@ -35,7 +36,18 @@ To install this module, you need to:
 Configuration
 =============
 
-No additional configuration is required.
+To print the installment amounts discriminated by line, you need to:
+
+#. Go to *Sales > Configuration > Settings > Quotations & Orders*.
+#. Enable *Payment Options Display: Discriminate by sale order line*.
+
+With that option enabled the printed quotation shows, under each line, the amount per
+installment of every payment option (e.g. *3 installments of $ 41,600.00 | 6 installments
+of $ 24,000.00*), the order-wide payment options table is not printed and the standard
+totals summary is shown instead. The setting is per company.
+
+The installment amounts are always computed on the line amount with taxes included, no
+matter whether the report prints the line amounts with or without taxes.
 
 Usage
 =====

--- a/sale_payment_options/__manifest__.py
+++ b/sale_payment_options/__manifest__.py
@@ -20,7 +20,7 @@
 {
     "name": "Sale Payment Options",
     "summary": "Manage and display payment options on quotations and sales orders.",
-    "version": "19.0.1.2.0",
+    "version": "19.0.1.3.0",
     "category": "Sales",
     "author": "ADHOC SA",
     "website": "www.adhoc.com.ar",
@@ -28,6 +28,7 @@
     "depends": ["sale", "card_installment"],
     "data": [
         "security/ir.model.access.csv",
+        "views/res_config_settings_views.xml",
         "views/sale_order_views.xml",
         "views/sale_payment_option_template_views.xml",
         "wizard/sale_payment_option_wizard_views.xml",

--- a/sale_payment_options/i18n/es.po
+++ b/sale_payment_options/i18n/es.po
@@ -28,6 +28,12 @@ msgid "% OV"
 msgstr "% OV"
 
 #. module: sale_payment_options
+#. odoo-python
+#: code:addons/sale_payment_options/models/sale_order_line.py:0
+msgid "%(installment_qty)s installments of %(amount)s"
+msgstr "%(installment_qty)s cuotas de %(amount)s"
+
+#. module: sale_payment_options
 #: model:ir.actions.report,print_report_name:sale_payment_options.action_report_saleorder_payment_options
 msgid ""
 "(object.state in ('draft', 'sent') and 'Quotation - %s' % (object.name)) or "
@@ -51,6 +57,16 @@ msgstr "Agregar opción de pago"
 #: model_terms:ir.ui.view,arch_db:sale_payment_options.view_sale_payment_option_wizard_form
 msgid "Cancel"
 msgstr "Cancelar"
+
+#. module: sale_payment_options
+#: model:ir.model,name:sale_payment_options.model_res_company
+msgid "Companies"
+msgstr "Compañías"
+
+#. module: sale_payment_options
+#: model:ir.model,name:sale_payment_options.model_res_config_settings
+msgid "Config Settings"
+msgstr "Ajustes de configuración"
 
 #. module: sale_payment_options
 #: model_terms:ir.ui.view,arch_db:sale_payment_options.view_sale_payment_option_wizard_form
@@ -94,6 +110,17 @@ msgstr "Moneda"
 #: model_terms:ir.ui.view,arch_db:sale_payment_options.view_sale_payment_option_template_form
 msgid "Details"
 msgstr "Detalles"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_res_company__sale_payment_options_by_line
+#: model:ir.model.fields,field_description:sale_payment_options.field_res_config_settings__sale_payment_options_by_line
+msgid "Discriminate Payment Options by Sale Line"
+msgstr "Discriminar opciones de pago por línea de venta"
+
+#. module: sale_payment_options
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.res_config_settings_view_form
+msgid "Discriminate by sale order line"
+msgstr "Discriminar por línea de venta"
 
 #. module: sale_payment_options
 #: model:ir.model.fields,field_description:sale_payment_options.field_sale_order__display_name
@@ -228,9 +255,24 @@ msgid "Payment Options"
 msgstr "Opciones de pago"
 
 #. module: sale_payment_options
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.res_config_settings_view_form
+msgid "Payment Options Display"
+msgstr "Visualización de opciones de pago"
+
+#. module: sale_payment_options
 #: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard_line__percentage
 msgid "Percentage"
 msgstr "Porcentaje"
+
+#. module: sale_payment_options
+#: model:ir.model.fields,help:sale_payment_options.field_res_company__sale_payment_options_by_line
+#: model:ir.model.fields,help:sale_payment_options.field_res_config_settings__sale_payment_options_by_line
+msgid ""
+"Print the installment amounts under each sale order line instead of the "
+"payment options table of the whole order."
+msgstr ""
+"Imprime los importes de las cuotas debajo de cada línea del pedido de venta "
+"en lugar de la tabla de opciones de pago de toda la orden."
 
 #. module: sale_payment_options
 #: model:ir.actions.report,name:sale_payment_options.action_report_saleorder_payment_options
@@ -267,6 +309,11 @@ msgstr "Línea de asistente de opción de pago de venta"
 #: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard__sale_order_id
 msgid "Sales Order"
 msgstr "Pedido de venta"
+
+#. module: sale_payment_options
+#: model:ir.model,name:sale_payment_options.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Línea de pedido de venta"
 
 #. module: sale_payment_options
 #: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option__sequence

--- a/sale_payment_options/i18n/sale_payment_options.pot
+++ b/sale_payment_options/i18n/sale_payment_options.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-19 19:53+0000\n"
-"PO-Revision-Date: 2026-06-19 19:53+0000\n"
+"POT-Creation-Date: 2026-07-31 13:36+0000\n"
+"PO-Revision-Date: 2026-07-31 13:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,6 +18,12 @@ msgstr ""
 #. module: sale_payment_options
 #: model_terms:ir.ui.view,arch_db:sale_payment_options.report_saleorder_payment_options_document
 msgid "% OV"
+msgstr ""
+
+#. module: sale_payment_options
+#. odoo-python
+#: code:addons/sale_payment_options/models/sale_order_line.py:0
+msgid "%(installment_qty)s installments of %(amount)s"
 msgstr ""
 
 #. module: sale_payment_options
@@ -41,6 +47,16 @@ msgstr ""
 #. module: sale_payment_options
 #: model_terms:ir.ui.view,arch_db:sale_payment_options.view_sale_payment_option_wizard_form
 msgid "Cancel"
+msgstr ""
+
+#. module: sale_payment_options
+#: model:ir.model,name:sale_payment_options.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: sale_payment_options
+#: model:ir.model,name:sale_payment_options.model_res_config_settings
+msgid "Config Settings"
 msgstr ""
 
 #. module: sale_payment_options
@@ -85,7 +101,21 @@ msgid "Details"
 msgstr ""
 
 #. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_res_company__sale_payment_options_by_line
+#: model:ir.model.fields,field_description:sale_payment_options.field_res_config_settings__sale_payment_options_by_line
+msgid "Discriminate Payment Options by Sale Line"
+msgstr ""
+
+#. module: sale_payment_options
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.res_config_settings_view_form
+msgid "Discriminate by sale order line"
+msgstr ""
+
+#. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_res_company__display_name
+#: model:ir.model.fields,field_description:sale_payment_options.field_res_config_settings__display_name
 #: model:ir.model.fields,field_description:sale_payment_options.field_sale_order__display_name
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_order_line__display_name
 #: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option__display_name
 #: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_template__display_name
 #: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard__display_name
@@ -106,7 +136,10 @@ msgid ""
 msgstr ""
 
 #. module: sale_payment_options
+#: model:ir.model.fields,field_description:sale_payment_options.field_res_company__id
+#: model:ir.model.fields,field_description:sale_payment_options.field_res_config_settings__id
 #: model:ir.model.fields,field_description:sale_payment_options.field_sale_order__id
+#: model:ir.model.fields,field_description:sale_payment_options.field_sale_order_line__id
 #: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option__id
 #: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_template__id
 #: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard__id
@@ -215,8 +248,21 @@ msgid "Payment Options"
 msgstr ""
 
 #. module: sale_payment_options
+#: model_terms:ir.ui.view,arch_db:sale_payment_options.res_config_settings_view_form
+msgid "Payment Options Display"
+msgstr ""
+
+#. module: sale_payment_options
 #: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard_line__percentage
 msgid "Percentage"
+msgstr ""
+
+#. module: sale_payment_options
+#: model:ir.model.fields,help:sale_payment_options.field_res_company__sale_payment_options_by_line
+#: model:ir.model.fields,help:sale_payment_options.field_res_config_settings__sale_payment_options_by_line
+msgid ""
+"Print the installment amounts under each sale order line instead of the "
+"payment options table of the whole order."
 msgstr ""
 
 #. module: sale_payment_options
@@ -253,6 +299,11 @@ msgstr ""
 #: model:ir.model,name:sale_payment_options.model_sale_order
 #: model:ir.model.fields,field_description:sale_payment_options.field_sale_payment_option_wizard__sale_order_id
 msgid "Sales Order"
+msgstr ""
+
+#. module: sale_payment_options
+#: model:ir.model,name:sale_payment_options.model_sale_order_line
+msgid "Sales Order Line"
 msgstr ""
 
 #. module: sale_payment_options

--- a/sale_payment_options/models/__init__.py
+++ b/sale_payment_options/models/__init__.py
@@ -1,3 +1,6 @@
 from . import sale_payment_option
 from . import sale_payment_option_template
 from . import sale_order
+from . import sale_order_line
+from . import res_company
+from . import res_config_settings

--- a/sale_payment_options/models/res_company.py
+++ b/sale_payment_options/models/res_company.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    sale_payment_options_by_line = fields.Boolean(
+        string="Discriminate Payment Options by Sale Line",
+        help="Print the installment amounts under each sale order line instead of the "
+        "payment options table of the whole order.",
+    )

--- a/sale_payment_options/models/res_config_settings.py
+++ b/sale_payment_options/models/res_config_settings.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    sale_payment_options_by_line = fields.Boolean(related="company_id.sale_payment_options_by_line", readonly=False)

--- a/sale_payment_options/models/sale_order_line.py
+++ b/sale_payment_options/models/sale_order_line.py
@@ -1,0 +1,67 @@
+from odoo import models
+from odoo.tools import float_is_zero
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _get_payment_options_installments(self):
+        """Installment breakdown of this line, one entry per order payment option.
+
+        Every entry is the list of segments of that payment option, so an option split
+        across plans (e.g. 50% in 3 installments + 50% in 6) keeps its segments together.
+        Surcharge and installment quantity are read from ``options_json`` so the printed
+        amounts match the option as it was quoted. Installments are always computed on
+        the line amount taxes included, no matter how the report prints the line, because
+        they are what the customer is going to pay, just like the order wide table.
+        """
+        self.ensure_one()
+        base_amount = self.price_total
+        if not base_amount:
+            return []
+
+        options = []
+        for option in self.order_id.payment_option_ids:
+            segments = []
+            for item in option.options_json or []:
+                installment_qty = item.get("installment_qty") or 0
+                percentage = item.get("percentage") or 0.0
+                if not installment_qty or not percentage:
+                    continue
+                surcharge_coefficient = 1.0 + (item.get("surcharge") or 0.0) / 100.0
+                amount = base_amount * percentage / 100.0 * surcharge_coefficient
+                segments.append(
+                    {
+                        "percentage": percentage,
+                        "installment_qty": installment_qty,
+                        "amount_per_installment": amount / installment_qty,
+                    }
+                )
+            if segments:
+                options.append(segments)
+        return options
+
+    def _get_payment_options_installments_display(self):
+        """Human readable installment breakdown, e.g. "3 installments of $ 30,000.00 | 6 installments of $ 15,000.00".
+
+        Options are separated by a pipe; segments of a single option split across plans are joined with a plus.
+        """
+        self.ensure_one()
+        currency = self.order_id.currency_id
+        rounding = currency.rounding or 0.01
+        options_display = []
+        for segments in self._get_payment_options_installments():
+            segments_display = []
+            for segment in segments:
+                if float_is_zero(segment["amount_per_installment"], precision_rounding=rounding):
+                    continue
+                segments_display.append(
+                    self.env._(
+                        "%(installment_qty)s installments of %(amount)s",
+                        installment_qty=segment["installment_qty"],
+                        amount=currency.format(segment["amount_per_installment"]),
+                    )
+                )
+            if segments_display:
+                options_display.append(" + ".join(segments_display))
+        return " | ".join(options_display)

--- a/sale_payment_options/report/sale_order_payment_options_report.xml
+++ b/sale_payment_options/report/sale_order_payment_options_report.xml
@@ -8,11 +8,23 @@
     </template>
 
     <template id="report_saleorder_payment_options_document" inherit_id="sale.report_saleorder_document">
+        <!-- The order totals are replaced by the payment options table, except when the options
+             are discriminated per line: there the standard totals are the only summary left. -->
         <xpath expr="//div[@name='so_total_summary']" position="attributes">
-            <attribute name="style">display: none;</attribute>
+            <attribute name="t-attf-style">#{'' if doc.company_id.sale_payment_options_by_line else 'display: none;'}</attribute>
+        </xpath>
+        <xpath expr="//tr[@name='tr_product']" position="after">
+            <t t-if="doc.company_id.sale_payment_options_by_line and not is_section and not is_subsection and not is_note and not is_combo and not line.is_downpayment">
+                <t t-set="installments_display" t-value="line._get_payment_options_installments_display()"/>
+                <tr t-if="installments_display" name="tr_payment_options_installments" class="fst-italic o_line_note">
+                    <td name="td_payment_options_installments" colspan="99" t-att-class="padding_class">
+                        <span t-out="installments_display"/>
+                    </td>
+                </tr>
+            </t>
         </xpath>
         <xpath expr="//div[@name='so_total_summary']" position="after">
-            <t t-if="doc.payment_option_ids">
+            <t t-if="doc.payment_option_ids and not doc.company_id.sale_payment_options_by_line">
                 <h3>Payment Options</h3>
                 <div>
                     <table class="o_has_total_table table o_main_table table-borderless">
@@ -39,20 +51,20 @@
                                 <t t-set="rowspan" t-value="len(opt.options_json) if opt.options_json else 1"/>
                                 <t t-foreach="opt.options_json" t-as="item" t-index="item_index">
                                     <tr>
-                                        <td class="text-start" t-if="item_index == 0" t-att-rowspan="rowspan"><t t-esc="op_index"/></td>
+                                        <td class="text-start" t-if="item_index == 0" t-att-rowspan="rowspan"><t t-out="op_index"/></td>
                                         <td class="text-start" t-if="item_index != 0" style="display:none"></td> <!-- The following hidden cell is used to keep table alignment when using rowspan for the index column. -->
-                                        <td class="text-start"><t t-esc="item.get('percentage')"/>%</td>
-                                        <td class="text-end text-nowrap"><t t-esc="item.get('card_installment')"/></td>
-                                        <td class="text-end"><t t-esc="item.get('surcharge')"/>%</td>
-                                        <td class="text-end"><t t-esc="item.get('subtotal')"/></td>
-                                        <td class="text-end"><span t-esc="'%.2f' % item.get('total_per_installment')"/></td>
-                                        <td class="text-end"><t t-esc="item.get('installment_qty')"/></td>
+                                        <td class="text-start"><t t-out="item.get('percentage')"/>%</td>
+                                        <td class="text-end text-nowrap"><t t-out="item.get('card_installment')"/></td>
+                                        <td class="text-end"><t t-out="item.get('surcharge')"/>%</td>
+                                        <td class="text-end"><span t-out="item.get('subtotal')" t-options="{'widget': 'monetary', 'display_currency': doc.currency_id}"/></td>
+                                        <td class="text-end"><span t-out="item.get('total_per_installment')" t-options="{'widget': 'monetary', 'display_currency': doc.currency_id}"/></td>
+                                        <td class="text-end"><t t-out="item.get('installment_qty')"/></td>
                                     </tr>
                                     <t t-set="subtotal" t-value="subtotal + item.get('subtotal')"/>
                                 </t>
                                 <tr class="fw-bold">
                                     <td colspan="4" class="text-end">Total</td>
-                                    <td class="text-end"><span t-esc="'%.2f' % subtotal"/></td>
+                                    <td class="text-end"><span t-out="subtotal" t-options="{'widget': 'monetary', 'display_currency': doc.currency_id}"/></td>
                                     <td></td>
                                     <td></td>
                                 </tr>

--- a/sale_payment_options/views/res_config_settings_views.xml
+++ b/sale_payment_options/views/res_config_settings_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.sale.payment.options</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="sale.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <block name="quotation_order_setting_container" position="inside">
+                <setting id="sale_payment_options_by_line" company_dependent="1"
+                         string="Payment Options Display"
+                         help="Discriminate by sale order line">
+                    <field name="sale_payment_options_by_line"/>
+                </setting>
+            </block>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
…r line

New per company setting "Payment Options Display: Discriminate by sale order line", in the Quotations & Orders block of the Sales settings. When it is enabled the printed quotation shows the amount per installment of every payment option under each sale order line, the order wide payment options table is no longer printed, and the standard totals summary is shown again (the module used to hide it unconditionally to replace it with that table).

The installment amounts are computed on the line amount the report already prints, and take the surcharge and the installment quantity from the payment option itself instead of the installment plan, so editing a plan afterwards does not change an already printed quotation. Options split across several plans keep their segments joined and prefixed with their percentage, to avoid printing them as if they were separate alternatives.

Also print the amounts of the payment options table with the monetary widget instead of raw floats, and replace t-esc with t-out.