### PR TITLE
[FIX] portal_sale_distributor: reapply noupdate security on migration

### DIFF
--- a/portal_sale_distributor/__manifest__.py
+++ b/portal_sale_distributor/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Portal Distributor Sale",
-    "version": "19.0.1.2.0",
+    "version": "19.0.1.3.0",
     "category": "Tools",
     "complexity": "easy",
     "author": "ADHOC SA, Odoo Community Association (OCA)",

--- a/portal_sale_distributor/migrations/19.0.1.3.0/post-migration.py
+++ b/portal_sale_distributor/migrations/19.0.1.3.0/post-migration.py
@@ -1,0 +1,18 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    base_group = env.ref("portal_sale_distributor.group_portal_backend_distributor")
+    if not base_group.privilege_id:
+        openupgrade.load_data(
+            env,
+            "portal_sale_distributor",
+            "security/portal_sale_distributor_security.xml",
+        )
+        base_group.invalidate_recordset()
+
+        stock_group = env.ref("portal_sale_distributor.group_portal_backend_distributor_stock")
+        missing_users = stock_group.user_ids - base_group.user_ids
+        if missing_users:
+            base_group.write({"user_ids": [(4, uid) for uid in missing_users.ids]})


### PR DESCRIPTION
The security file is noupdate="1", so on databases migrated from a previous version the pre-existing group_portal_backend_distributor did not receive the new privilege_id (Odoo 19 privileges framework). The distributor portal permission ends up misconfigured and updating the module does not fix it.

Add a post-migration that reloads the security data (load_data) to restore the group definition, and re-propagates the implied membership to existing distributor users so the base group recovers its members.