### PR TITLE
[FIX] portal_sale_distributor: don't override standard display_stock in product catalog

### DIFF
--- a/portal_sale_distributor/models/product_catalog_mixin.py
+++ b/portal_sale_distributor/models/product_catalog_mixin.py
@@ -5,10 +5,7 @@ class ProductCatalogMixin(models.AbstractModel):
     _inherit = "product.catalog.mixin"
 
     def _get_action_add_from_catalog_extra_context(self):
-        display_stock = (
-            True if self.env.user.has_group("portal_sale_distributor.group_portal_backend_distributor_stock") else False
-        )
-        return {
-            **super()._get_action_add_from_catalog_extra_context(),
-            "display_stock": display_stock,
-        }
+        ctx = super()._get_action_add_from_catalog_extra_context()
+        if self.env.user.has_group("portal_sale_distributor.group_portal_backend_distributor_stock"):
+            ctx["display_stock"] = True
+        return ctx


### PR DESCRIPTION
## Summary

`ProductCatalogMixin._get_action_add_from_catalog_extra_context()` in `portal_sale_distributor` replaced `display_stock` unconditionally based on `group_portal_backend_distributor_stock`, instead of extending the value computed by `super()` (`sale_stock`, `mrp`, etc.). As a result, any user without that specific group lost the on-hand quantity indicator in the product catalog Kanban (`stock.product_view_kanban_catalog`), even for regular internal sale orders with storable products — a regression from standard Odoo behavior.

Introduced in #1587 (@lef-adhoc).

## Fix

Merge into the standard `display_stock` instead of overriding it: the distributor group can only force it `True`, it no longer hides stock for regular backend users.

## Test plan

- As an internal user without `portal_sale_distributor.group_portal_backend_distributor_stock`, open a sale order's product catalog with storable products in stock → "On Hand" shows as in standard Odoo.
- As a user with the distributor group → still shows "On Hand" as before.

Internal ref: Helpdesk ticket #124272.