### PR TITLE
[FIX] sale_exceptions_ignore_approve: no confirmation mail on aborted confirm

### DIFF
--- a/sale_exceptions_ignore_approve/README.rst
+++ b/sale_exceptions_ignore_approve/README.rst
@@ -36,6 +36,8 @@ Usage
 To use this module, you need to:
 
 #. When Ignoring a sale Exception, approve directly the sale order.
+#. The quotation template confirmation mail is not sent when the confirmation
+   is aborted by an exception, so the customer does not get it twice.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot

--- a/sale_exceptions_ignore_approve/__manifest__.py
+++ b/sale_exceptions_ignore_approve/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Sale Exceptions Ingore Approve Directly',
-    'version': "17.0.1.1.0",
+    'version': "17.0.1.2.0",
     'category': 'Sale',
     'sequence': 14,
     'author': 'ADHOC SA',
@@ -28,6 +28,7 @@
     'summary': '',
     'depends': [
         'sale_exception',
+        'sale_management',
     ],
     'external_dependencies': {
     },

--- a/sale_exceptions_ignore_approve/models/__init__.py
+++ b/sale_exceptions_ignore_approve/models/__init__.py
@@ -2,5 +2,4 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from . import models
-from . import wizards
+from . import sale_order

--- a/sale_exceptions_ignore_approve/models/sale_order.py
+++ b/sale_exceptions_ignore_approve/models/sale_order.py
@@ -1,0 +1,17 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    def _send_order_notification_mail(self, mail_template):
+        """No mandar el mail del template si la confirmación se abortó."""
+        aborted = self.state != 'sale' and (
+            mail_template == self.sale_order_template_id.mail_template_id)
+        if aborted:
+            return
+        return super()._send_order_notification_mail(mail_template)

--- a/sale_exceptions_ignore_approve/tests/__init__.py
+++ b/sale_exceptions_ignore_approve/tests/__init__.py
@@ -2,5 +2,4 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from . import models
-from . import wizards
+from . import test_confirm_notification_mail

--- a/sale_exceptions_ignore_approve/tests/test_confirm_notification_mail.py
+++ b/sale_exceptions_ignore_approve/tests/test_confirm_notification_mail.py
@@ -1,0 +1,49 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests.common import TransactionCase
+
+
+class TestConfirmNotificationMail(TransactionCase):
+
+    def test_ignorar_excepcion_manda_un_solo_mail(self):
+        """Ignorar una excepción confirma la OV y manda el mail una sola vez."""
+        self.env['exception.rule'].search([]).write({'active': False})
+        self.env['exception.rule'].create({
+            'name': 'Regla de test',
+            'model': 'sale.order',
+            'exception_type': 'by_py_code',
+            'code': 'failed = True',
+        })
+        mail_template = self.env['mail.template'].create({
+            'name': 'Test confirmacion',
+            'model_id': self.env.ref('sale.model_sale_order').id,
+            'subject': 'TEST CONFIRMACION',
+            'body_html': '<p>ok</p>',
+            'auto_delete': False,
+        })
+        order = self.env['sale.order'].create({
+            'partner_id': self.env['res.partner'].create({'name': 'Test'}).id,
+            'sale_order_template_id': self.env['sale.order.template'].create({
+                'name': 'Template de test',
+                'mail_template_id': mail_template.id,
+            }).id,
+            'order_line': [(0, 0, {
+                'product_id': self.env['product.product'].create({
+                    'name': 'Servicio de test',
+                    'type': 'service',
+                }).id,
+            })],
+        })
+
+        order.action_confirm()
+        self.env['sale.exception.confirm'].with_context(
+            active_id=order.id,
+            active_ids=order.ids,
+            active_model=order._name,
+        ).create({'ignore': True}).action_confirm()
+
+        self.assertEqual(order.state, 'sale')
+        self.assertEqual(len(order.message_ids.filtered(
+            lambda m: m.subject == 'TEST CONFIRMACION')), 1)


### PR DESCRIPTION
## Problema

`sale_management.action_confirm()` (core, `sale_management/models/sale_order.py:168-181`) manda el mail del quotation template sin chequear el retorno de `super().action_confirm()`:

```python
res = super().action_confirm()
...
for order in self:
    if order.sale_order_template_id.mail_template_id:
        order._send_order_notification_mail(...)
```

`sale_exception.action_confirm()` aborta devolviendo la acción del popup, sin llamar a `super()`. La orden queda sin confirmar, pero el mail sale igual. Cuando después se ignora la excepción y se confirma de verdad, el mail sale una segunda vez: **el cliente lo recibe dos veces**.

Aplica a cualquier OV que combine un quotation template con mail template y una exception rule que salte al confirmar.

## Cambio

Override de `_send_order_notification_mail` que saltea el envío mientras la orden no esté confirmada. Acotado a la plantilla del quotation template, para no tocar `_send_payment_succeeded_for_order_mail`, el otro caller del método, que sí puede disparar legítimamente sobre una orden no confirmada.

`sale_management` agregado a `depends`, ya que el override actúa sobre el envío que agrega ese módulo.

## Test plan

Un test que reproduce el flujo del ticket: excepción que salta, popup, ignorar, confirmar. Verificado en Odoo 17.0.

Con el fix:

```
0 failed, 0 error(s) of 1 tests
```

Sin el fix:

```
FAIL: TestConfirmNotificationMail.test_ignorar_excepcion_manda_un_solo_mail
AssertionError: 2 != 1
```

El assert es `== 1`, no `== 0`: si el fix rompiera el envío legítimo, el test fallaría igual.

## Notas

- La causa de fondo está en core. Corresponde además un PR upstream a `odoo/odoo` con el guard `if not (isinstance(res, bool) and res): return res`, que es lo que ya hace `sale_order_type_automation` con el comentario *"we use this because compatibility with sale exception module"*.
- Falta el forward-port a 18.0/19.0.
- Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/124484