### PR TITLE
[FIX] sale_order_type_automation: fix payment automation on refunds

### DIFF
--- a/sale_order_type_automation/models/account_move.py
+++ b/sale_order_type_automation/models/account_move.py
@@ -9,12 +9,16 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     def _prepare_dict_account_payment(self, invoice, payment_journal):
-        partner_type = invoice.move_type in ("out_invoice", "out_refund") and "customer" or "supplier"
         return {
-            "reconciled_invoice_ids": [(6, 0, invoice.ids)],
+            # reconciled_invoice_ids is a non stored computed field without inverse, so
+            # writing it here was a no-op. invoice_ids is the stored m2m holding the link
+            "invoice_ids": [(6, 0, invoice.ids)],
             "amount": invoice.amount_residual,
             "partner_id": invoice.partner_id.id,
-            "partner_type": partner_type,
+            "partner_type": "customer" if invoice.is_sale_document() else "supplier",
+            # refunds move the money on the opposite direction of the document they fix,
+            # otherwise a customer refund would be registered as an inbound receipt
+            "payment_type": "inbound" if invoice.is_inbound() else "outbound",
             "journal_id": payment_journal.id,
             "date": fields.Date.context_today(self),
             "currency_id": invoice.currency_id.id,

--- a/sale_order_type_automation/models/sale_order_type.py
+++ b/sale_order_type_automation/models/sale_order_type.py
@@ -78,7 +78,8 @@ class SaleOrderType(models.Model):
         "Payment Journal",
         domain="payment_journal_domain",
         help="Journal used only with payment_automation. As manual payment "
-        "method is used, only journals with manual method are shown. "
+        "method is used, only journals with an inbound and an outbound manual "
+        "method are shown, since refunds are paid on the opposite direction. "
         "This field will not be considered for sales coming from eCommerce. "
         "You should configure it directly in Settings > Website.",
         store=True,
@@ -113,7 +114,10 @@ class SaleOrderType(models.Model):
             rec.payment_journal_domain = (
                 Domain(rec.env["account.journal"]._check_company_domain(rec.invoice_company_id))
                 & Domain("type", "in", ["cash", "bank"])
+                # both directions are required: invoices are paid with an inbound payment
+                # and refunds with an outbound one
                 & Domain("inbound_payment_method_line_ids.code", "=", "manual")
+                & Domain("outbound_payment_method_line_ids.code", "=", "manual")
             )
 
     @api.constrains("invoice_company_id", "payment_journal_id")
@@ -122,7 +126,13 @@ class SaleOrderType(models.Model):
             if rec.payment_journal_id and rec.payment_journal_id not in rec.env["account.journal"].search(
                 rec.payment_journal_domain
             ):
-                raise ValidationError("The selected 'Payment Journal' does not belong to the selected invoice company.")
+                raise ValidationError(
+                    _(
+                        "The selected 'Payment Journal' is not valid for the selected invoice company. "
+                        "Only cash or bank journals of that company with an inbound and an outbound "
+                        "manual payment method can be used."
+                    )
+                )
 
     @api.depends()
     def _compute_auto_done_setting(self):

--- a/sale_order_type_automation/tests/__init__.py
+++ b/sale_order_type_automation/tests/__init__.py
@@ -5,3 +5,4 @@
 
 from . import test_sale_order_type_automation
 from . import test_invoice_automation_error
+from . import test_payment_automation

--- a/sale_order_type_automation/tests/test_payment_automation.py
+++ b/sale_order_type_automation/tests/test_payment_automation.py
@@ -1,0 +1,97 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.exceptions import ValidationError
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPaymentAutomation(AccountTestInvoicingCommon):
+    @classmethod
+    def setup_independent_user(cls):
+        # Keep superuser context for setup in deployments with stricter product ACLs.
+        return None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.payment_journal = cls.company_data["default_journal_bank"]
+        cls.sale_type = cls.env["sale.order.type"].create(
+            {
+                "name": "Test Payment Automation",
+                "company_id": cls.env.company.id,
+                "payment_atomation": "validate_payment",
+                "payment_journal_id": cls.payment_journal.id,
+            }
+        )
+
+    @classmethod
+    def _create_move(cls, move_type, **kwargs):
+        return cls._create_invoice_one_line(move_type=move_type, price_unit=100.0, tax_ids=[], **kwargs)
+
+    def test_prepare_payment_vals_follow_document_direction(self):
+        """El sentido del pago se deriva del tipo de documento, no del partner_type:
+        una NC de cliente devuelve plata y una NC de proveedor la recibe."""
+        expected = {
+            "out_invoice": ("customer", "inbound"),
+            "out_refund": ("customer", "outbound"),
+            "in_invoice": ("supplier", "outbound"),
+            "in_refund": ("supplier", "inbound"),
+        }
+        for move_type, (partner_type, payment_type) in expected.items():
+            with self.subTest(move_type=move_type):
+                move = self._create_move(move_type)
+                vals = self.env["account.move"]._prepare_dict_account_payment(move, self.payment_journal)
+                self.assertEqual(vals["partner_type"], partner_type)
+                self.assertEqual(vals["payment_type"], payment_type)
+
+    def test_customer_invoice_registers_inbound_payment(self):
+        invoice = self._create_move("out_invoice", sale_type_id=self.sale_type)
+
+        invoice.action_post()
+
+        payment = invoice.reconciled_payment_ids
+        self.assertEqual(len(payment), 1, "La automatización debe crear un único pago")
+        self.assertEqual(payment.partner_type, "customer")
+        self.assertEqual(payment.payment_type, "inbound", "Cobrar una factura de cliente entra plata")
+        self.assertEqual(invoice.amount_residual, 0.0, "El pago debe quedar conciliado con la factura")
+        self.assertEqual(invoice.matched_payment_ids, payment, "El pago debe quedar linkeado a la factura")
+
+    def test_customer_refund_registers_outbound_payment(self):
+        """Ticket 124193: la NC de cliente registraba un recibo de dinero (inbound)
+        en lugar de una devolución (outbound), dejando el asiento contable invertido."""
+        refund = self._create_move("out_refund", sale_type_id=self.sale_type)
+
+        refund.action_post()
+
+        payment = refund.reconciled_payment_ids
+        self.assertEqual(len(payment), 1, "La automatización debe crear un único pago")
+        self.assertEqual(payment.partner_type, "customer")
+        self.assertEqual(payment.payment_type, "outbound", "Devolver una NC de cliente saca plata")
+        self.assertEqual(refund.amount_residual, 0.0, "El pago debe quedar conciliado con la NC")
+        self.assertEqual(refund.matched_payment_ids, payment, "El pago debe quedar linkeado a la NC")
+        receivable_line = payment.move_id.line_ids.filtered(lambda x: x.account_type == "asset_receivable")
+        self.assertGreater(
+            receivable_line.debit,
+            0.0,
+            "La devolución debe debitar la cuenta a cobrar, revirtiendo el cobro original",
+        )
+
+    def test_payment_journal_requires_manual_method_on_both_directions(self):
+        """Sin método manual outbound el journal no sirve para pagar una NC, así que
+        no debe poder configurarse en el tipo de orden de venta."""
+        journal = self.env["account.journal"].create(
+            {
+                "name": "Bank Without Outbound Manual",
+                "type": "bank",
+                "code": "BNKNO",
+                "company_id": self.env.company.id,
+            }
+        )
+        journal.outbound_payment_method_line_ids.unlink()
+
+        self.assertNotIn(journal, self.env["account.journal"].search(self.sale_type.payment_journal_domain))
+        with self.assertRaises(ValidationError):
+            self.sale_type.payment_journal_id = journal

--- a/sale_order_type_automation/tests/test_sale_order_type_automation.py
+++ b/sale_order_type_automation/tests/test_sale_order_type_automation.py
@@ -31,6 +31,7 @@ class TestSaleOrderTypeAutomation(TransactionCase):
             [
                 ("type", "in", ["cash", "bank"]),
                 ("inbound_payment_method_line_ids.code", "=", "manual"),
+                ("outbound_payment_method_line_ids.code", "=", "manual"),
                 ("company_id", "=", cls.sale_type.invoice_company_id.id),
             ],
             limit=1,


### PR DESCRIPTION
## Problem

Sale order types with `payment_atomation = validate_payment` created a wrong payment on credit notes:

- `payment_type` was never passed to `account.payment.create()`, so it fell back to the field default (`inbound`). A customer credit note therefore produced a money receipt instead of a refund, the payment could not be reconciled against the credit note, and the resulting accounting entries were reversed.
- `reconciled_invoice_ids` was passed on create, but on `account.payment` that is a non stored computed field with no inverse (`addons/account/models/account_payment.py`), so the write was dropped and the payment was never linked to its invoice.
- The `Payment Journal` domain only required an *inbound* manual payment method. An outbound payment needs an outbound one too, so posting the payment of a credit note can fail with `Please define a payment method line on your payment`.

## Fix

- Derive `partner_type` and `payment_type` from the document itself with `is_sale_document()` / `is_inbound()`. This also covers vendor credit notes (`supplier` + `inbound`).
- Use `invoice_ids`, the stored m2m that actually holds the link, instead of `reconciled_invoice_ids`.
- Require a manual method on both directions in `_compute_payment_journal_domain`, and reword `_check_payment_journal_company`: its message blamed the invoice company even when the real problem was the missing payment method.

## Test plan

New `sale_order_type_automation/tests/test_payment_automation.py`:

| Test | Checks |
|---|---|
| `test_prepare_payment_vals_follow_document_direction` | `partner_type` / `payment_type` for the four invoice move types |
| `test_customer_invoice_registers_inbound_payment` | inbound payment, reconciled, linked to the invoice |
| `test_customer_refund_registers_outbound_payment` | outbound payment, reconciled, linked, receivable line debited |
| `test_payment_journal_requires_manual_method_on_both_directions` | a bank journal without an outbound manual method is rejected |

`test_sale_order_type_automation.py` picks its payment journal with the same domain as the model.

```
odoo -d <db> -u sale_order_type_automation --test-enable --test-tags /sale_order_type_automation
odoo.tests.result: 0 failed, 0 error(s) of 10 tests
```

Every new assertion was checked to fail with the two models reverted (`3 failed, 0 error(s) of 10 tests`), so the tests do cover the regression.

Ref: https://www.adhoc.inc/odoo/helpdesk.ticket/124193
