### PR TITLE
[FIX] sale_stock_ux: full return should leave sale order as "nothing to invoice"

### DIFF
--- a/sale_stock_ux/models/sale_order_line.py
+++ b/sale_stock_ux/models/sale_order_line.py
@@ -322,13 +322,20 @@ class SaleOrderLine(models.Model):
                 line.qty_to_invoice = qty_to_invoice_corrected
 
     @api.depends(
-        "order_id.force_invoiced_status", "state", "product_uom_qty", "qty_delivered", "qty_to_invoice", "qty_invoiced"
+        "order_id.force_invoiced_status",
+        "state",
+        "product_uom_qty",
+        "qty_delivered",
+        "qty_to_invoice",
+        "qty_invoiced",
+        "quantity_returned",
     )
     def _compute_invoice_status(self):
         super()._compute_invoice_status()
         precision = self.env["decimal.precision"].precision_get("Product Unit of Measure")
         for line in self:
             if not line.order_id.force_invoiced_status:
+                net_qty = line.product_uom_qty - line.quantity_returned
                 if not float_is_zero(line.qty_to_invoice, precision_digits=precision):
                     line.invoice_status = "to invoice"
                 elif (
@@ -338,11 +345,14 @@ class SaleOrderLine(models.Model):
                     and float_compare(line.qty_delivered, line.product_uom_qty, precision_digits=precision) == 1
                 ):
                     line.invoice_status = "upselling"
-                elif (
-                    float_compare(
-                        line.qty_invoiced, (line.product_uom_qty - line.quantity_returned), precision_digits=precision
-                    )
-                    >= 0
+                elif float_compare(line.qty_invoiced, net_qty, precision_digits=precision) >= 0 and (
+                    # Sin devolución mantenemos la semántica nativa (una línea de
+                    # cantidad 0 queda "invoiced"). Con devolución solo es "invoiced"
+                    # si quedó una cantidad neta positiva a facturar; si se devolvió
+                    # todo (neto 0), no hay nada que facturar y cae a "no", igual que
+                    # el core de Odoo. Ver ticket 123997.
+                    float_is_zero(line.quantity_returned, precision_digits=precision)
+                    or float_compare(net_qty, 0.0, precision_digits=precision) > 0
                 ):
                     line.invoice_status = "invoiced"
                 else:

--- a/sale_stock_ux/tests/__init__.py
+++ b/sale_stock_ux/tests/__init__.py
@@ -2,3 +2,4 @@ from . import test_action_cancel
 from . import test_kit_return_uom
 from . import test_return_of_return
 from . import test_stock_info_batching
+from . import test_invoice_status_return

--- a/sale_stock_ux/tests/test_invoice_status_return.py
+++ b/sale_stock_ux/tests/test_invoice_status_return.py
@@ -31,8 +31,10 @@ class TestInvoiceStatusReturn(AccountTestInvoicingCommon):
             }
         )
         # Evitar que reglas de excepción bloqueen la confirmación en runbot.
+        # sudo() porque el usuario de AccountTestInvoicingCommon no está en el
+        # grupo "Exception manager" y sin él el write falla con AccessError.
         if cls.env["sale.order"]._fields.get("ignore_exception"):
-            cls.env["exception.rule"].search([("active", "=", True)]).write({"active": False})
+            cls.env["exception.rule"].sudo().search([("active", "=", True)]).write({"active": False})
 
     def _create_order(self, qty):
         order = self.env["sale.order"].create(

--- a/sale_stock_ux/tests/test_invoice_status_return.py
+++ b/sale_stock_ux/tests/test_invoice_status_return.py
@@ -1,0 +1,114 @@
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestInvoiceStatusReturn(AccountTestInvoicingCommon):
+    """Estado de facturación de la OV tras devoluciones (ticket 123997).
+
+    En ``sale_stock_ux`` una devolución PARCIAL totalmente facturada debe
+    quedar "invoiced" (lo entregado neto se facturó), pero una devolución
+    TOTAL debe caer a "no" (no queda nada por facturar), igual que el core de
+    Odoo. Antes del fix la devolución total quedaba erróneamente "invoiced".
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.warehouse = cls.env["stock.warehouse"].search([("company_id", "=", cls.env.company.id)], limit=1)
+        # Entrega en 1 paso para un escenario determinista.
+        cls.warehouse.delivery_steps = "ship_only"
+        cls.partner = cls.env["res.partner"].create({"name": "Test Partner", "customer_rank": 1})
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test almacenable",
+                "type": "consu",
+                "is_storable": True,
+                "invoice_policy": "order",
+                "list_price": 100.0,
+                "property_account_income_id": cls.company_data["default_account_revenue"].id,
+                "property_account_expense_id": cls.company_data["default_account_expense"].id,
+            }
+        )
+        # Evitar que reglas de excepción bloqueen la confirmación en runbot.
+        if cls.env["sale.order"]._fields.get("ignore_exception"):
+            cls.env["exception.rule"].search([("active", "=", True)]).write({"active": False})
+
+    def _create_order(self, qty):
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "warehouse_id": self.warehouse.id,
+                "order_line": [(0, 0, {"product_id": self.product.id, "product_uom_qty": qty, "price_unit": 100.0})],
+            }
+        )
+        order.action_confirm()
+        return order
+
+    def _validate(self, picking):
+        picking.action_confirm()
+        picking.action_assign()
+        for move in picking.move_ids:
+            move.move_line_ids.unlink()
+            move.quantity = move.product_uom_qty
+            move.picked = True
+        picking._action_done()
+
+    def _make_return(self, picking, quantity):
+        wizard = (
+            self.env["stock.return.picking"]
+            .with_context(active_id=picking.id, active_ids=picking.ids, active_model="stock.picking")
+            .create({})
+        )
+        for line in wizard.product_return_moves:
+            line.to_refund = True
+            line.quantity = quantity
+        action = wizard.action_create_returns()
+        returned = self.env["stock.picking"].browse(action["res_id"])
+        self._validate(returned)
+        return returned
+
+    def _invoice(self, order):
+        invoices = order._create_invoices(final=True)
+        invoices.action_post()
+        return invoices
+
+    def test_total_return_is_nothing_to_invoice(self):
+        """Devolución total: tras la nota de crédito el estado es "no"."""
+        order = self._create_order(1.0)
+        line = order.order_line
+        delivery = order.picking_ids
+        self._validate(delivery)
+        self._invoice(order)
+        self.assertEqual(line.invoice_status, "invoiced", "Entregado y facturado debe ser 'invoiced'")
+
+        # Devolvemos TODO -> queda pendiente la nota de crédito.
+        self._make_return(delivery, quantity=1.0)
+        self.assertEqual(line.invoice_status, "to invoice", "Con la NC pendiente debe ser 'to invoice'")
+
+        # Emitimos la nota de crédito -> no queda nada por facturar.
+        self._invoice(order)
+        self.assertEqual(line.invoice_status, "no", "Devolución total facturada debe quedar 'no' (nada que facturar)")
+
+    def test_partial_return_stays_invoiced(self):
+        """Devolución parcial: tras la nota de crédito sigue "invoiced"."""
+        order = self._create_order(2.0)
+        line = order.order_line
+        delivery = order.picking_ids
+        self._validate(delivery)
+        self._invoice(order)
+        self.assertEqual(line.invoice_status, "invoiced")
+
+        self._make_return(delivery, quantity=1.0)
+        self.assertEqual(line.invoice_status, "to invoice")
+
+        self._invoice(order)
+        self.assertEqual(line.invoice_status, "invoiced", "Devolución parcial facturada neta debe quedar 'invoiced'")
+
+    def test_no_return_full_invoice_stays_invoiced(self):
+        """Sin devolución: entregado y facturado queda "invoiced" (no regresión)."""
+        order = self._create_order(3.0)
+        line = order.order_line
+        self._validate(order.picking_ids)
+        self._invoice(order)
+        self.assertEqual(line.invoice_status, "invoiced")


### PR DESCRIPTION
Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/123997

### Problem
When a sale order is delivered and invoiced and then **fully returned** (with the corresponding refund credit note), the order line stayed in `invoice_status = "invoiced"` ("Fully invoiced") instead of falling back to `"no"` ("Nothing to invoice") as Odoo core does. A **partial** return of a fully-invoiced order correctly stays `"invoiced"`.

### Root cause
The `_compute_invoice_status` override in `sale_stock_ux/models/sale_order_line.py` set a line to `"invoiced"` whenever:

```python
qty_invoiced >= (product_uom_qty - quantity_returned)
```

On a full return the net quantity `(product_uom_qty - quantity_returned)` is `0` and `qty_invoiced` is also `0`, so `0 >= 0` matched and the line was wrongly flagged as invoiced. The override was designed for the partial-return case but did not contemplate a full return.

### Fix
Only keep `"invoiced"` when there is actually something to invoice: either there is no return at all (native semantics preserved, incl. a legit 0-qty line) or the net quantity to invoice is strictly positive (partial return / normal sale). When everything was returned (net `0`), the status falls through to `"no"`, matching Odoo core.

`quantity_returned` is also added to the compute dependencies (previously it was only reached transitively via `qty_to_invoice`).

### Test plan
Added `sale_stock_ux/tests/test_invoice_status_return.py` (post_install):

- `test_total_return_is_nothing_to_invoice`: deliver + invoice + full return + credit note → `"no"`.
- `test_partial_return_stays_invoiced`: deliver + invoice + partial return + credit note → `"invoiced"`.
- `test_no_return_full_invoice_stays_invoiced`: deliver + invoice, no return → `"invoiced"` (no regression).

Verified red-before / green-after: the total-return test fails on the current code (`AssertionError: 'invoiced' != 'no'`) and all three pass with the fix.