### PR TITLE
[FIX] sale_ux: recompute discount on confirmed orders with triple discount

### DIFF
--- a/sale_ux/models/sale_order_line.py
+++ b/sale_ux/models/sale_order_line.py
@@ -53,6 +53,8 @@ class SaleOrderLine(models.Model):
         return super()._get_protected_fields() + ["discount"]
 
     def _compute_discount(self):
+        if "discount1" in self._fields:
+            return super()._compute_discount()
         lines = self.filtered(
             lambda x: x.order_id.state == "sale"
             and not (x.order_id.pricelist_id and x.pricelist_item_id._show_discount())


### PR DESCRIPTION
## Problem

On a **confirmed** sale order, editing a discount on a line did not recompute the line subtotal when `sale_triple_discount` is installed.

`sale_ux._compute_discount` skips confirmed-order lines that have no pricelist discount, in order to preserve a manually kept `discount`. This is correct while `discount` is a plain manual field. But `sale_triple_discount` turns `discount` into a computed aggregate of `discount1/2/3`, and its override runs *below* `sale_ux` in the MRO. By passing a reduced recordset to `super()`, `sale_ux` prevented the aggregation from ever running for confirmed lines, so both `discount` and `price_subtotal` stayed stale.

## Fix

When `sale_triple_discount` is installed, `_compute_discount` no longer skips any line: the aggregation always runs. Its dependencies are limited to the discount fields, so this does not reset the discount on quantity/product changes. Without triple discount, the original behaviour is unchanged.