### PR TITLE
[IMP] sale_stock_ux: batch stock-by-location and reserved qty computes

### DIFF
--- a/sale_stock_ux/models/sale_order_line.py
+++ b/sale_stock_ux/models/sale_order_line.py
@@ -2,6 +2,8 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
+from collections import defaultdict
+
 from odoo import _, api, fields, models
 from odoo.tools.float_utils import float_compare, float_is_zero
 
@@ -60,12 +62,24 @@ class SaleOrderLine(models.Model):
 
     @api.depends("product_id", "product_uom_qty")
     def _compute_total_reserved_quantity(self):
-        for line in self:
-            loc_id = line.order_id.warehouse_id.lot_stock_id.id
-            stock_quants = self.env["stock.quant"].search(
-                [("product_id", "=", line.product_id.id), ("location_id", "child_of", loc_id)]
-            )
-            line.total_reserved_quantity = sum(stock_quants.mapped("reserved_quantity"))
+        # Batched: one grouped query per distinct warehouse stock location instead
+        # of a stock.quant search per line (avoids an N+1 on the order form load).
+        self.total_reserved_quantity = 0.0
+        lines = self.filtered(lambda line: line.product_id and line.order_id.warehouse_id.lot_stock_id)
+        for root_location, root_lines in lines.grouped(lambda line: line.order_id.warehouse_id.lot_stock_id).items():
+            reserved_by_product = {
+                product.id: reserved
+                for product, reserved in self.env["stock.quant"]._read_group(
+                    domain=[
+                        ("product_id", "in", root_lines.product_id.ids),
+                        ("location_id", "child_of", root_location.id),
+                    ],
+                    groupby=["product_id"],
+                    aggregates=["reserved_quantity:sum"],
+                )
+            }
+            for line in root_lines:
+                line.total_reserved_quantity = reserved_by_product.get(line.product_id.id, 0.0)
 
     @api.depends("qty_delivered", "quantity_returned")
     def _compute_all_qty_delivered(self):
@@ -336,37 +350,33 @@ class SaleOrderLine(models.Model):
 
     @api.depends("product_template_id")
     def _compute_stock_by_location(self):
-        for line in self:
-            if not line.product_id:
-                line.stock_by_location = ""
-                continue
+        # Batched: a single grouped query for every product in the recordset instead
+        # of a stock.quant read_group per line (avoids an N+1 on the order form load).
+        self.stock_by_location = ""
+        lines = self.filtered("product_id")
+        if not lines:
+            return
 
-            stock_quants = self.env["stock.quant"].read_group(
-                domain=[
-                    ("location_id.usage", "=", "internal"),
-                    ("product_id", "=", line.product_id.id),
-                    ("quantity", ">", 0),
-                ],
-                fields=["location_id", "available_quantity:sum"],
-                groupby=["location_id"],
-                lazy=False,
-            )
+        available_by_product = defaultdict(list)
+        for product, location, available_quantity in self.env["stock.quant"]._read_group(
+            domain=[
+                ("location_id.usage", "=", "internal"),
+                ("product_id", "in", lines.product_id.ids),
+                ("quantity", ">", 0),
+            ],
+            groupby=["product_id", "location_id"],
+            aggregates=["available_quantity:sum"],
+        ):
+            if available_quantity > 0:
+                available_by_product[product.id].append((location.display_name, available_quantity))
 
+        for line in lines:
             stock_lines = []
-
-            for stock in stock_quants:
-                location_name = stock["location_id"][1]
-                free_qty = stock["available_quantity"]
-
-                if free_qty > 0:
-                    if line.product_uom and line.product_uom != line.product_id.uom_id:
-                        free_qty = line.product_id.uom_id._compute_quantity(free_qty, line.product_uom)
-
-                    stock_lines.append(f"{location_name}: {free_qty:.2f} {line.product_uom.name}")
-
-            line.stock_by_location = "\n".join(stock_lines) if stock_lines else ""
-
-        (self - self).stock_by_location = ""
+            for location_name, free_qty in available_by_product.get(line.product_id.id, []):
+                if line.product_uom and line.product_uom != line.product_id.uom_id:
+                    free_qty = line.product_id.uom_id._compute_quantity(free_qty, line.product_uom)
+                stock_lines.append(f"{location_name}: {free_qty:.2f} {line.product_uom.name}")
+            line.stock_by_location = "\n".join(stock_lines)
 
     def _get_protected_fields(self):
         """Override to allow modifications when skip_locked_order_line_check context is set."""

--- a/sale_stock_ux/tests/__init__.py
+++ b/sale_stock_ux/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_action_cancel
 from . import test_kit_return_uom
 from . import test_return_of_return
+from . import test_stock_info_batching

--- a/sale_stock_ux/tests/test_stock_info_batching.py
+++ b/sale_stock_ux/tests/test_stock_info_batching.py
@@ -1,0 +1,172 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestStockInfoBatching(TransactionCase):
+    """`stock_by_location` y `total_reserved_quantity` se resuelven en lote.
+
+    Ambos campos viven en la vista de líneas del pedido, así que se recalculan
+    en cada onchange de la cabecera. Consultaban `stock.quant` una vez por línea:
+    en una orden de 293 líneas eso daba ~1.700 consultas y ~4,6 s. Ver ticket
+    124420 (backport de ingadhoc/sale#1762).
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.uom_unit = self.env.ref("uom.product_uom_unit")
+        self.uom_dozen = self.env.ref("uom.product_uom_dozen")
+
+        self.warehouse = self.env["stock.warehouse"].search([("company_id", "=", self.env.company.id)], limit=1)
+        self.loc_a = self.env["stock.location"].create(
+            {"name": "Test Batching A", "usage": "internal", "location_id": self.warehouse.lot_stock_id.id}
+        )
+        self.loc_b = self.env["stock.location"].create(
+            {"name": "Test Batching B", "usage": "internal", "location_id": self.warehouse.lot_stock_id.id}
+        )
+
+        self.partner = self.env["res.partner"].create({"name": "Test Partner Batching", "customer_rank": 1})
+
+        # 10 en A con 4 reservadas (6 disponibles) y 5 en B.
+        self.product_a = self._make_product("Producto A", [(self.loc_a, 10, 4), (self.loc_b, 5, 0)])
+        # Solo en B, sin reservas.
+        self.product_b = self._make_product("Producto B", [(self.loc_b, 7, 0)])
+        # Sin quants en ninguna ubicación.
+        self.product_c = self._make_product("Producto C")
+
+    def _make_product(self, name, quants=()):
+        product = self.env["product.product"].create(
+            {
+                "name": name,
+                "type": "consu",
+                "is_storable": True,
+                "uom_id": self.uom_unit.id,
+                "uom_po_id": self.uom_unit.id,
+            }
+        )
+        for location, quantity, reserved in quants:
+            self.env["stock.quant"]._update_available_quantity(product, location, quantity)
+            if reserved:
+                self.env["stock.quant"]._update_reserved_quantity(product, location, reserved)
+        return product
+
+    def _make_order(self, line_vals):
+        return self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "warehouse_id": self.warehouse.id,
+                "order_line": [(0, 0, vals) for vals in line_vals],
+            }
+        )
+
+    def _query_count(self, lines, field_name):
+        """Consultas que cuesta recalcular `field_name` sobre `lines`, ya calientes.
+
+        El primer cálculo llena la cache de los campos que el compute lee
+        (producto, UdM, ubicaciones); invalidando solo el campo computado, lo
+        que se mide después es el acceso a `stock.quant` y nada más.
+        """
+        lines.mapped(field_name)
+        lines.invalidate_recordset([field_name])
+        before = self.env.cr.sql_log_count
+        lines.mapped(field_name)
+        return self.env.cr.sql_log_count - before
+
+    def _expected_line(self, location, qty, uom):
+        return f"{location.display_name}: {qty:.2f} {uom.name}"
+
+    def test_stock_by_location_values_per_line(self):
+        """Cada línea muestra el stock disponible de SU producto, sin cruzarse."""
+        order = self._make_order(
+            [
+                {"product_id": self.product_a.id, "product_uom_qty": 1.0},
+                {"product_id": self.product_b.id, "product_uom_qty": 1.0},
+                {"product_id": self.product_c.id, "product_uom_qty": 1.0},
+                {"display_type": "line_section", "name": "Sección"},
+            ]
+        )
+        line_a, line_b, line_c, section = order.order_line
+
+        # Producto A: 6 disponibles en A (10 menos 4 reservadas) y 5 en B.
+        self.assertEqual(
+            set(line_a.stock_by_location.split("\n")),
+            {
+                self._expected_line(self.loc_a, 6.0, self.uom_unit),
+                self._expected_line(self.loc_b, 5.0, self.uom_unit),
+            },
+        )
+        # Producto B: solo la ubicación donde tiene stock, sin arrastrar la de A.
+        self.assertEqual(line_b.stock_by_location, self._expected_line(self.loc_b, 7.0, self.uom_unit))
+        self.assertEqual(line_c.stock_by_location, "")
+        self.assertEqual(section.stock_by_location, "")
+
+    def test_stock_by_location_converts_uom_per_line(self):
+        """Dos líneas del mismo producto en distinta UdM no comparten el valor convertido."""
+        product = self._make_product("Producto Docenas", [(self.loc_a, 24, 0)])
+        order = self._make_order(
+            [
+                {"product_id": product.id, "product_uom_qty": 1.0, "product_uom": self.uom_unit.id},
+                {"product_id": product.id, "product_uom_qty": 1.0, "product_uom": self.uom_dozen.id},
+            ]
+        )
+        line_units, line_dozens = order.order_line
+
+        self.assertEqual(line_units.stock_by_location, self._expected_line(self.loc_a, 24.0, self.uom_unit))
+        self.assertEqual(line_dozens.stock_by_location, self._expected_line(self.loc_a, 2.0, self.uom_dozen))
+
+    def test_stock_by_location_queries_do_not_scale_with_lines(self):
+        """El costo del cálculo no depende de cuántas líneas tenga el pedido."""
+        few = [self._make_product(f"Producto pocos {i}", [(self.loc_a, 5, 0)]) for i in range(3)]
+        many = [self._make_product(f"Producto muchos {i}", [(self.loc_a, 5, 0)]) for i in range(12)]
+        order_few = self._make_order([{"product_id": p.id, "product_uom_qty": 1.0} for p in few])
+        order_many = self._make_order([{"product_id": p.id, "product_uom_qty": 1.0} for p in many])
+
+        queries_few = self._query_count(order_few.order_line, "stock_by_location")
+        queries_many = self._query_count(order_many.order_line, "stock_by_location")
+
+        self.assertEqual(
+            queries_many,
+            queries_few,
+            "stock_by_location vuelve a consultar stock.quant por línea (N+1)",
+        )
+
+    def test_total_reserved_quantity_only_counts_warehouse_stock(self):
+        """Suma lo reservado bajo la ubicación del almacén del pedido, y nada más."""
+        outside = self.env["stock.location"].create(
+            {
+                "name": "Test Batching Fuera",
+                "usage": "internal",
+                "location_id": self.env.ref("stock.stock_location_locations").id,
+            }
+        )
+        self.env["stock.quant"]._update_available_quantity(self.product_a, outside, 20)
+        self.env["stock.quant"]._update_reserved_quantity(self.product_a, outside, 9)
+
+        order = self._make_order(
+            [
+                {"product_id": self.product_a.id, "product_uom_qty": 1.0},
+                {"product_id": self.product_c.id, "product_uom_qty": 1.0},
+                {"display_type": "line_section", "name": "Sección"},
+            ]
+        )
+        line_a, line_c, section = order.order_line
+
+        # Las 4 reservadas en A; las 9 de la ubicación externa quedan afuera.
+        self.assertAlmostEqual(line_a.total_reserved_quantity, 4.0)
+        self.assertAlmostEqual(line_c.total_reserved_quantity, 0.0)
+        self.assertAlmostEqual(section.total_reserved_quantity, 0.0)
+
+    def test_total_reserved_quantity_queries_do_not_scale_with_lines(self):
+        """El costo del cálculo no depende de cuántas líneas tenga el pedido."""
+        few = [self._make_product(f"Reservado pocos {i}", [(self.loc_a, 5, 2)]) for i in range(3)]
+        many = [self._make_product(f"Reservado muchos {i}", [(self.loc_a, 5, 2)]) for i in range(12)]
+        order_few = self._make_order([{"product_id": p.id, "product_uom_qty": 1.0} for p in few])
+        order_many = self._make_order([{"product_id": p.id, "product_uom_qty": 1.0} for p in many])
+
+        queries_few = self._query_count(order_few.order_line, "total_reserved_quantity")
+        queries_many = self._query_count(order_many.order_line, "total_reserved_quantity")
+
+        self.assertEqual(
+            queries_many,
+            queries_few,
+            "total_reserved_quantity vuelve a consultar stock.quant por línea (N+1)",
+        )


### PR DESCRIPTION
Backport de #1762 (mergeado en 19.0) a 18.0.

`stock_by_location` y `total_reserved_quantity` están en la vista de líneas del pedido, así que se recalculan en cada onchange de la cabecera. Ambos consultaban `stock.quant` una vez por línea, con lo cual el costo del onchange crecía linealmente con el tamaño del pedido: en órdenes de varios cientos de líneas eso son cientos de consultas por cada modificación.

## Cambios

- `_compute_total_reserved_quantity`: pasa de un `search` por línea a un `_read_group` por ubicación raíz de almacén, agregando `reserved_quantity:sum` por producto.
- `_compute_stock_by_location`: pasa de un `read_group` por línea a un único `_read_group` agrupado por producto y ubicación para todos los productos del recordset. El armado del texto y la conversión de UdM siguen resolviéndose por línea.

Sin cambios de comportamiento: mismos valores, mismo alcance (`child_of` de la ubicación del almacén para lo reservado, ubicaciones internas con stock para el detalle por ubicación).

## Diferencias con el PR original de 19.0

- Usa `product_uom` en lugar de `product_uom_id` (el campo se renombró en 19.0).
- No incluye el filtro `location_id.show_stock_on_products`: en 19.0 ese filtro llegó junto con la dependencia a `product_stock_by_location`, que este módulo no declara en 18.0. Agregarlo sería un cambio funcional, fuera del alcance de este backport.

## Test plan

Se agrega `sale_stock_ux/tests/test_stock_info_batching.py` (5 tests):

- Valores por línea con productos y ubicaciones distintas, descuento de lo reservado, producto sin stock y línea de sección sin producto.
- Conversión de UdM por línea: el mismo producto en dos líneas con UdM distintas da valores distintos.
- Alcance de lo reservado: cuenta lo que está bajo la ubicación del almacén del pedido e ignora ubicaciones internas fuera de ese árbol.
- Dos tests que comparan el conteo de consultas entre un pedido de 3 líneas y uno de 12: sin este cambio dan 3 vs 12 (una consulta por línea), con el cambio dan lo mismo.

```
odoo -d <base> -u sale_stock_ux --test-tags /sale_stock_ux:TestStockInfoBatching
0 failed, 0 error(s) of 5 tests
```

Consultas a `stock.quant` medidas sobre una base 18.0 con este cambio aplicado, por cada recálculo del campo:

| Líneas del pedido | `stock_by_location` | `total_reserved_quantity` |
| --- | --- | --- |
| 10 | 1 | 1 |
| 100 | 1 | 1 |
| 250 | 1 | 1 |

Antes: una consulta por línea en cada uno de los dos campos.
