### PR TITLE
[FIX] sale_order_type_automation: keep the print action of the validated pickings

### DIFF
--- a/sale_order_type_automation/models/sale_order.py
+++ b/sale_order_type_automation/models/sale_order.py
@@ -98,12 +98,38 @@ class SaleOrder(models.Model):
             )
         ):
             order_line.qty_delivered = order_line.product_uom_qty
+        print_actions = []
         for rec in self.filtered(lambda x: x.type_id.picking_atomation != "none" and x.procurement_group_id):
-            rec._process_pickings()
-        return True
+            # ``or []`` porque _process_pickings puede estar extendido y no devolver nada:
+            # que no imprima es tolerable, que no se pueda confirmar la venta no.
+            print_actions += rec._process_pickings() or []
+        return self._merge_picking_print_actions(print_actions) or True
+
+    def _merge_picking_print_actions(self, actions):
+        """Junta los reportes a imprimir en una sola acción ``do_multi_print``.
+
+        Lo que no sea un reporte se descarta a propósito: ``button_validate`` puede
+        devolver un asistente (backorder, por ejemplo) y acá no hay cliente que lo
+        ejecute, igual que antes de propagar nada."""
+        reports = []
+        for action in actions:
+            if not isinstance(action, dict):
+                continue
+            if action.get("tag") == "do_multi_print":
+                reports += (action.get("params") or {}).get("reports") or []
+            elif action.get("type") == "ir.actions.report":
+                reports.append(action)
+        if not reports:
+            return False
+        return {
+            "type": "ir.actions.client",
+            "tag": "do_multi_print",
+            "params": {"reports": reports},
+        }
 
     def _process_pickings(self, prev_pending=None):
         self.ensure_one()
+        print_actions = []
         pickings = self.picking_ids.filtered(lambda x: x.state not in ("done", "cancel"))
         for pick in pickings.sorted(lambda p: p.picking_type_id.sequence):
             pick.action_assign()
@@ -122,13 +148,16 @@ class SaleOrder(models.Model):
                     )
                 for op in pick.move_line_ids:
                     op.with_context(sale_automation=True).quantity = op.quantity_product_uom
-            pick.button_validate()
+            # Validamos server-side: si descartamos la acción de impresión que
+            # devuelve button_validate, nadie la ejecuta y no se imprime nada.
+            print_actions.append(pick.button_validate())
             pending_after = self.picking_ids.filtered(lambda x: x.state not in ("done", "cancel"))
             if pending_after:
                 pending_after.action_assign()
         pending_final = self.picking_ids.filtered(lambda x: x.state not in ("done", "cancel"))
         if pending_final and pending_final != (prev_pending or set()):
-            self._process_pickings(prev_pending=pending_final)
+            print_actions += self._process_pickings(prev_pending=pending_final) or []
+        return print_actions
 
     def action_confirm(self):
         res = super().action_confirm()

--- a/sale_order_type_automation/tests/__init__.py
+++ b/sale_order_type_automation/tests/__init__.py
@@ -3,4 +3,4 @@
 # directory
 ##############################################################################
 
-from . import test_sale_order_type_automation
+from . import test_picking_automation_print, test_sale_order_type_automation

--- a/sale_order_type_automation/tests/test_picking_automation_print.py
+++ b/sale_order_type_automation/tests/test_picking_automation_print.py
@@ -1,0 +1,66 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests.common import TransactionCase
+
+
+class TestPickingAutomationPrint(TransactionCase):
+    """La automatización valida los pickings server-side: si descarta lo que
+    devuelve ``button_validate`` no se imprime nada (ticket 124899)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+        cls.warehouse.delivery_steps = "ship_only"
+        cls.partner = cls.env["res.partner"].create({"name": "Cliente automatización"})
+        # Consumible: la validación no depende de que haya stock disponible.
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Producto automatización",
+                "type": "consu",
+            }
+        )
+        cls.sale_type = cls.env["sale.order.type"].create(
+            {
+                "name": "Tipo automatizado test",
+                "picking_atomation": "validate_no_force",
+                "invoicing_atomation": "none",
+                "warehouse_id": cls.warehouse.id,
+            }
+        )
+        # Con reglas de excepción activas action_confirm devuelve su asistente y la
+        # automatización no llega a correr.
+        if "exception.rule" in cls.env:
+            cls.env["exception.rule"].search([("model", "in", ("sale.order", "sale.order.line"))]).write(
+                {"active": False}
+            )
+
+    def _confirm_automated_sale(self):
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "type_id": self.sale_type.id,
+                "warehouse_id": self.warehouse.id,
+                "order_line": [(0, 0, {"product_id": self.product.id, "product_uom_qty": 1.0})],
+            }
+        )
+        res = order.action_confirm()
+        self.assertEqual(order.state, "sale", "La venta no quedó confirmada: la automatización no corrió.")
+        self.assertEqual(order.picking_ids.state, "done", "La automatización debe validar la entrega.")
+        return order, res
+
+    def test_print_action_propagated(self):
+        self.warehouse.out_type_id.auto_print_delivery_slip = True
+        _order, res = self._confirm_automated_sale()
+        self.assertIsInstance(res, dict, "action_confirm debe devolver la acción de impresión, no descartarla.")
+        reports = res.get("params", {}).get("reports", [])
+        self.assertIn("stock.report_deliveryslip", [report.get("report_name") for report in reports])
+
+    def test_no_print_action_when_flag_is_off(self):
+        # Sin imprimir al validar no hay nada que propagar: action_confirm tiene que
+        # seguir devolviendo True como hasta ahora.
+        self.warehouse.out_type_id.auto_print_delivery_slip = False
+        _order, res = self._confirm_automated_sale()
+        self.assertIs(res, True)


### PR DESCRIPTION
## Problema

La automatización de entregas valida los pickings server-side y **descartaba** lo que devuelve `button_validate`. En ese retorno viaja la acción de impresión:

- la que arma el core cuando el tipo de operación tiene `auto_print_delivery_slip` (acción de cliente `do_multi_print`, ver `stock/models/stock_picking.py` → `_get_autoprint_report_actions`), y
- la que agregan encima los módulos de remito.

Resultado: confirmar el pedido de venta validaba la entrega pero **no imprimía nada**, aunque el tipo de operación estuviera configurado para imprimir al validar. Nótese que esto rompe también el autoprint **nativo** de Odoo, no sólo el de los remitos.

## Cambio

`_process_pickings` junta las acciones a lo largo del loop de pickings — incluida la pasada recursiva para los que quedan listos después, que es el caso de las entregas en dos pasos, donde la acción la devuelve el segundo paso — y `action_confirm` las devuelve fusionadas en un único `do_multi_print`, la misma forma que usa el core. Lo que no es un reporte (un asistente, `True`) se descarta como hasta ahora.

Cuando no hay nada que imprimir, `action_confirm` sigue devolviendo `True`: no cambia nada para los tipos de pedido cuyos tipos de operación no piden imprimir al validar. Los llamadores no-UI de `action_confirm` en el core (pagos, portal, `sale_project`) ignoran el valor de retorno.

El comentario `# because it's needed to return actions if exists` que ya estaba en `action_confirm` describía esta intención; faltaba que la cadena devolviera algo.

## Test plan

`sale_order_type_automation/tests/test_picking_automation_print.py`, clase nueva:

- `test_print_action_propagated_one_step`: depósito de un paso, tipo de operación con `auto_print_delivery_slip` → `action_confirm` devuelve el `do_multi_print` con `stock.report_deliveryslip`.
- `test_print_action_propagated_two_steps`: dos pasos; valida que la acción del OUT no se pierda al recorrer el PICK primero (assert de los dos pickings en `done`).
- `test_no_print_action_when_flag_is_off`: sin el flag, `action_confirm` sigue devolviendo `True` (guarda de no-regresión).

No necesita módulos de remito: alcanza con el `auto_print_delivery_slip` nativo.

Verificado con `-u stock_voucher_ux,stock_voucher_ux_iot,sale_order_type_automation --test-enable` sobre una base 18.0: **3 failed sin el fix / 0 failed con el fix** de 13 tests.

Va bundleado con https://github.com/ingadhoc/stock/pull/991 (mismo branch): ese PR hace que el remito quede numerado en la validación, este hace que además se imprima. Cada uno arregla su mitad y son independientes.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/124899