### PR TITLE
[FIX] sale_ux: don't use date widget on create_date

### DIFF
--- a/sale_ux/views/sale_order_views.xml
+++ b/sale_ux/views/sale_order_views.xml
@@ -124,7 +124,7 @@
                 <field name="amount_to_invoice" optional="hide"/>
             </field>
             <field name="date_order" position="before">
-                <field name="create_date" widget="date" optional="hide"/>
+                <field name="create_date" options="{'show_time': False}" optional="hide"/>
             </field>
 
             <!-- As we unify menus we make the draft more visible -->


### PR DESCRIPTION
The `date` widget only supports `date` fields (`supportedTypes: ["date"]` in `web/static/src/views/fields/datetime/datetime_field.js`), so using it on the `create_date` datetime column logs a warning on every sale order list render:

```
WARNING odoo.http: The widget: date don't support the type datetime
```

The `show_time` option on the default datetime widget keeps the intended date-only display without the warning.

## Test plan

- Open the sale order list view and enable the optional `Create Date` column: it shows the date without time, same as before.
- No `The widget: date don't support the type datetime` warning in the log.

Replaces #1806, which had the same commit on a branch name shared with a PR in another repo. Runbot bundles same-named branches into a single build, so that PR inherited an unrelated failure. Same change, on its own branch.