### PR TITLE
[FIX] sale_loyalty_ux: don't compute rewards banner for portal users

### DIFF
--- a/sale_loyalty_ux/models/sale_order.py
+++ b/sale_loyalty_ux/models/sale_order.py
@@ -28,8 +28,14 @@ class SaleOrder(models.Model):
         "coupon_point_ids",
     )
     def _compute_loyalty_rewards_banner_visible(self):
+        # The banner is a salesperson tool, and looking for claimable rewards ends up reading the
+        # company contact (_get_program_timezone), which portal users can not read. Computing it
+        # for them raises an AccessError that keeps the sale order form from opening.
+        is_internal_user = self.env.user.has_group("base.group_user")
         for order in self:
             order.loyalty_rewards_banner_visible = False
+            if not is_internal_user:
+                continue
             if order.state not in ("draft", "sent"):
                 continue
             if order.order_line.filtered("is_reward_line"):


### PR DESCRIPTION
`_compute_loyalty_rewards_banner_visible` calls `_get_claimable_rewards()`, which ends up in `sale_loyalty`:

```python
def _get_program_timezone(self):
    return (
        self.company_id.partner_id.tz  # not sudoed
        or self.env['ir.config_parameter'].sudo().get_param('loyalty.timezone', 'UTC')
    )
```

Portal users can only read their own commercial partner and its children, so reading the company contact raises an `AccessError`. Since the compute depends on `partner_id`, `company_id` and `order_line`, it runs on the onchange that builds a new order — meaning **a portal user with backend access (e.g. a distributor through `portal_sale_distributor`) can not open the sale order form at all**.

The banner is a salesperson tool, so it is skipped for non internal users.

## Test plan

- Log in as a distributor (`portal_sale_distributor.group_portal_backend_distributor`), open Sales and create a new order: the form opens (before this change it did not).
- Log in as an internal user: the rewards banner still shows when there are claimable rewards.

Verified locally by running the `portal_sale_distributor_tour` as `portal-backend` on a database with `sale_loyalty`, `sale_project`, `sale_timesheet` and `sale_stock` installed: the tour got past the form-opening step it was failing at.