### PR TITLE
[FIX] portal_sale_distributor: let a distributor save a sale order

### DIFF
--- a/portal_sale_distributor/models/sale_order.py
+++ b/portal_sale_distributor/models/sale_order.py
@@ -85,6 +85,10 @@ class SaleOrder(models.Model):
                 + arch.xpath("//label[@for='recurrence_id']")
                 + arch.xpath("//field[@name='recurrence_id']")
                 + arch.xpath("//button[@name='update_date_prices_and_validity']")
+                # its invisible modifier reads project_ids, and computing that field searches
+                # projects by reinvoiced_sale_order_id, restricted to salesmen. Hiding the button
+                # drops the modifier, so the field is no longer added to the view nor read.
+                + arch.xpath("//button[@name='action_view_milestone']")
             )
             for node in invisible_fields:
                 node.set("invisible", "1")

--- a/portal_sale_distributor/models/sale_order_line.py
+++ b/portal_sale_distributor/models/sale_order_line.py
@@ -2,11 +2,22 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import models
+from odoo import api, models
 
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # sale_margin adds stored precomputed fields restricted to internal users (margin,
+        # margin_percent, purchase_price). On create the ORM computes them and then reads them
+        # back with the current user, which raises an AccessError for a distributor and keeps the
+        # order from being saved. Create as superuser and hand the records back in the user env,
+        # so the fields stay hidden for them.
+        if self.env.user.has_group("portal_sale_distributor.group_portal_backend_distributor"):
+            return super(SaleOrderLine, self.sudo()).create(vals_list).with_env(self.env)
+        return super().create(vals_list)
 
     def _compute_purchase_price(self):
         self = self.sudo()


### PR DESCRIPTION
A distributor (portal user with backend access) could not save a sale order. Two unrelated fields raised an `AccessError`:

**`margin` (sale_margin), on create.** The field is `store=True, precompute=True, groups="base.group_user"`, so the ORM computes it while the line is created and then reads it back with the current user:

```
sale_order_line create → _prepare_create_values → _add_precomputed_values
  → record["margin"] → AccessError
```

This happens inside `create`, so neither hiding the field in the view nor overriding the compute helps. The line is created as superuser and the records are handed back in the user environment, so the elevation does not outlive the create and the cost fields stay hidden for the distributor.

**`project_ids` (sale_project), on save.** The `action_view_milestone` button has `invisible="not is_product_milestone or not project_ids or state == 'draft'"`, so the view adds `<field name="project_ids" invisible="True" data-used-by=...>` and reads it. Computing it searches projects by `reinvoiced_sale_order_id`, restricted to salesmen. Hiding the button drops the modifier, so the field is no longer added nor read — same treatment the module already gives to other fields of modules it does not depend on.

## Test plan

Ran `portal_sale_distributor_tour` as `portal-backend` on a database with `sale_margin`, `sale_project`, `sale_timesheet`, `sale_loyalty` and `sale_stock` installed: the tour creates the order, adds a product, confirms and the form is saved (`tour succeeded`). Without these changes it fails when saving.

That tour is the one enabled by [ingadhoc/demo#339](https://github.com/ingadhoc/demo/pull/339).

## Worth a look while reviewing

`_compute_purchase_price` right above the new `create` most likely never runs: this module does not depend on `sale_margin`, so `sale_margin` is loaded later and its compute wins. I verified this exact behaviour with a marker inside an equivalent override of `_compute_project_ids` — it never executed. Left untouched here to keep this change focused.