### PR TITLE
[FIX] sale_ux: down payment invoiced in a different currency

### DIFF
--- a/sale_ux/models/account_move.py
+++ b/sale_ux/models/account_move.py
@@ -38,21 +38,3 @@ class AccountMove(models.Model):
         (self - moves).has_sales = False
         for rec in moves:
             rec.has_sales = any(line for line in rec.invoice_line_ids.mapped("sale_line_ids"))
-
-    # Evaluar en proximas verciones si Odoo lo resuelve
-    def action_post(self):
-        res = super(AccountMove, self).action_post()
-        downpayment_lines = self.line_ids.sale_line_ids.filtered(lambda l: l.is_downpayment and not l.display_type)
-        for downpayment_line in downpayment_lines:
-            # When change currency in downpayment
-            if self.currency_id != downpayment_line.currency_id:
-                downpayment_invoice_line = self.invoice_line_ids.filtered(
-                    lambda l: l.is_downpayment and l.sale_line_ids.ids == downpayment_line.ids
-                )
-                downpayment_invoice_line.ensure_one()
-                price_unit = downpayment_invoice_line.price_unit
-                converted_price_unit = self.currency_id._convert(
-                    price_unit, downpayment_line.currency_id, self.company_id, self.invoice_date or fields.Date.today()
-                )
-                downpayment_line.price_unit = converted_price_unit
-        return res

--- a/sale_ux/models/sale_order.py
+++ b/sale_ux/models/sale_order.py
@@ -173,6 +173,7 @@ class SaleOrder(models.Model):
 
     def _create_invoices(self, grouped=False, final=False, date=None):
         invoices = super()._create_invoices(grouped=grouped, final=final, date=date)
+        self._fix_multicurrency_downpayment_amounts(invoices)
         precision = self.env["decimal.precision"].precision_get("Product Unit of Measure")
         filtered_invoices = invoices.filtered(
             lambda i: float_is_zero(i.amount_total, precision_digits=precision)
@@ -181,6 +182,27 @@ class SaleOrder(models.Model):
         filtered_invoices.action_switch_move_type()
         filtered_invoices.mapped("invoice_line_ids").mapped(lambda line: line.write({"quantity": abs(line.quantity)}))
         return invoices
+
+    def _fix_multicurrency_downpayment_amounts(self, invoices):
+        for move in invoices.filtered(lambda m: m.state == "draft" and m.move_type in ("out_invoice", "out_refund")):
+            downpayment_lines = move.invoice_line_ids.filtered(
+                lambda line: line.is_downpayment and line.display_type == "product"
+            )
+            other_currency_dp = downpayment_lines.sale_line_ids.invoice_lines.filtered(
+                lambda line: line.move_id != move
+                and line.move_id.state != "cancel"
+                and line.currency_id != move.currency_id
+            )
+            if not other_currency_dp:
+                continue
+            for line in downpayment_lines:
+                price_unit = line.price_unit
+                move.with_context(skip_is_manually_modified=True).write(
+                    {"invoice_line_ids": [Command.update(line.id, {"price_unit": price_unit + 1.0})]}
+                )
+                move.with_context(skip_is_manually_modified=True).write(
+                    {"invoice_line_ids": [Command.update(line.id, {"price_unit": price_unit})]}
+                )
 
     def action_preview_sale_order(self):
         """Open sale Preview in a new Tab"""

--- a/sale_ux/models/sale_order_line.py
+++ b/sale_ux/models/sale_order_line.py
@@ -58,3 +58,19 @@ class SaleOrderLine(models.Model):
             and not (x.order_id.pricelist_id and x.pricelist_item_id._show_discount())
         )
         super(SaleOrderLine, self - lines)._compute_discount()
+
+    def _get_downpayment_line_price_unit(self, invoices):
+        total = super()._get_downpayment_line_price_unit(invoices)
+        for line in self.invoice_lines:
+            if line.move_id.state != "posted" or line.move_id in invoices:
+                continue
+            if line.currency_id and self.currency_id and line.currency_id != self.currency_id:
+                sign = 1 if line.move_id.move_type == "out_invoice" else -1
+                converted_price_unit = line.currency_id._convert(
+                    line.price_unit,
+                    self.currency_id,
+                    line.company_id,
+                    line.move_id.invoice_date or line.move_id.date or fields.Date.context_today(self),
+                )
+                total += sign * (converted_price_unit - line.price_unit)
+        return total


### PR DESCRIPTION
## Problema

Con una orden de venta en una moneda (ej. USD), al facturar un **anticipo** y cambiarle la moneda a otra (ej. ARS) con `account_invoice_move_currency`, confirmarlo, y luego crear la factura del saldo: el primer borrador sale bien, pero si se **cancela y se vuelve a crear**, la factura final calcula mal (montos desproporcionados) y hasta se convierte en **Nota de Crédito**.

## Causa

El código core de anticipos de `sale` asume que la factura de anticipo está en la misma moneda que la orden. Suma importes de la factura de anticipo (en la moneda cambiada) sin convertir, en dos lugares:

1. `sale.order.line._get_downpayment_line_price_unit`: copia el `price_unit` de la línea de anticipo (moneda cambiada) sobre la línea de la orden (que sigue en la moneda de la orden). Se dispara desde `account.move.action_post` **y** `button_cancel` — el workaround previo en `sale_ux` solo cubría el post, por eso "recién al cancelar se rompe".
2. `sale.order._create_invoices` (bloque de corrección de redondeo `delta_amount`): suma `price_total` de la factura de anticipo y de la factura final mezclando monedas, corrompiendo las líneas de impuesto y de la cuenta por cobrar (total erróneo / flip a nota de crédito).

## Solución

- Override de `_get_downpayment_line_price_unit` que convierte cada línea de factura de anticipo en otra moneda a la moneda de la línea de la orden antes de sumar (cubre post **y** cancel). Reemplaza el workaround parcial que estaba en `action_post` (removido).
- En `_create_invoices`, cuando el anticipo viene de otra moneda, se fuerza el recálculo de las líneas dinámicas (impuesto/cuenta por cobrar) del asiento final para descartar el `delta` cross-currency espurio del core.

## Pruebas

Validado end-to-end (crear anticipo USD → pasar a ARS → confirmar → crear factura final → cancelar → recrear):
- Antes: 2ª factura final = nota de crédito con montos disparatados.
- Después: 1ª y 2ª factura final = factura normal con el saldo correcto.
- Regresión anticipo en la misma moneda: total sin cambios.