### PR TITLE
[FIX] portal_sale_distributor: don't break the chatter for portal users

### DIFF
--- a/portal_sale_distributor/models/sale_order.py
+++ b/portal_sale_distributor/models/sale_order.py
@@ -107,3 +107,11 @@ class SaleOrder(models.Model):
     def action_update_prices(self):
         self = self.sudo()
         super().action_update_prices()
+
+    def _message_get_suggested_recipients_batch(self, **kwargs):
+        # to keep odoobot out of the suggestions, mail reads base.partner_root.email_normalized
+        # without sudo, and a portal user can not read that contact: the chatter fails to load
+        # right after the distributor confirms the order. They do not add recipients anyway.
+        if not self.env.user.has_group("base.group_user"):
+            return {record.id: [] for record in self}
+        return super()._message_get_suggested_recipients_batch(**kwargs)


### PR DESCRIPTION
Right after a distributor confirms an order, loading the chatter fails:

```
POST /mail/data → Sorry, John Portal Advanced (id=7) doesn't have 'read' access to: Contact (res.partner)
```

The read comes from the suggested recipients of the chatter. To keep odoobot out of the suggestions, `mail` reads its contact without sudo (`mail/models/models.py`):

```python
# ban emails: never propose odoobot nor aliases
ban_emails = [self.env.ref('base.partner_root').email_normalized]
```

A portal user can not read that contact, so the whole request fails. Suggested recipients are a salesperson tool — a distributor does not add recipients to the thread — so they are skipped for non internal users. No sudo involved: computing them as superuser would hand the portal user a list built with elevated access.

This is the last thing keeping [ingadhoc/demo#339](https://github.com/ingadhoc/demo/pull/339) from being green.

## Test plan

Ran `portal_sale_distributor_tour` as `portal-backend` on a database with `sale_margin`, `sale_project`, `sale_timesheet`, `sale_loyalty` and `sale_stock` installed: `tour succeeded`, and no `Access Denied ... res.partner` left in the log. Before this change the tour passed too, but the log kept that error and runbot fails a build on it.

## Worth knowing

The messages this module posts on confirmation are authored by odoobot, because `message_post` is called on `self.sudo()` — which is why the body has to say *"Pedido confirmado por {user}"*. Not touched here (it is not what breaks the chatter), but it looks worth fixing on its own.