### PR TITLE
[IMP] sale_order_type_automation: schedule background posting by date

### DIFF
--- a/sale_order_type_automation/models/sale_order.py
+++ b/sale_order_type_automation/models/sale_order.py
@@ -49,7 +49,7 @@ class SaleOrder(models.Model):
             # usamos final para que reste adelantos y tmb por ej
             # por si se usa el modulo de facturar las returns
             if rec.type_id.background_post:
-                rec = rec.with_context(default_background_post=True)
+                rec = rec.with_context(default_background_post_date=fields.Datetime.now())
             invoices = rec._create_invoices(final=True)
             if not invoices:
                 continue


### PR DESCRIPTION
## What

`account_background_post` replaces its `background_post` boolean with a `background_post_date` datetime (ingadhoc/account-invoicing#312). The invoicing automation of the sale order type has to default the new field, otherwise it silently stops scheduling the invoices: Odoo ignores a `default_` context key pointing at a field that no longer exists, so the invoices would just be created without any schedule and stay in draft forever.

## Changes

- `run_invoicing_atomation` sets `default_background_post_date` with the current datetime instead of `default_background_post=True`.

The `background_post` boolean on `sale.order.type` is untouched: it is the configuration checkbox of the order type, not the schedule of the invoice.

## Test plan

With a sale order type set to `validate_invoice` + "Validate Invoice in Background", confirming an order:

- creates the invoice and leaves it in draft, without validating it synchronously,
- schedules it through the new field,
- and the background cron then posts it and clears the schedule.

## Linked

- ingadhoc/account-invoicing#312 — the field this change depends on. Both branches share the same name so runbot builds them together.

Task: https://www.adhoc.inc/mail/view?model=project.task&res_id=72206