### PR TITLE
[FIX] portal_sale_distributor: keep the contact autocomplete working for portal users

### DIFF
--- a/portal_sale_distributor/models/partner.py
+++ b/portal_sale_distributor/models/partner.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
@@ -9,3 +9,27 @@ class ResPartner(models.Model):
     credit_limit = fields.Float(
         groups="account.group_account_invoice,account.group_account_readonly,portal_sale_distributor.group_portal_backend_distributor"
     )
+
+    @api.model
+    def web_name_search(self, name, specification, domain=None, operator="ilike", limit=100):
+        """Keep the contact autocomplete working for portal users.
+
+        On top of the display name, the web client asks for a formatted one, and computing it
+        reads parent_id.name (res.partner._compute_display_name). A portal user can be allowed
+        to read a contact and not its parent, and then the whole search fails with an
+        AccessError instead of returning what it can read. Only the label formatting is done as
+        superuser: the search itself still runs as the user, so record rules pick the results,
+        and the parent name is already part of the display name of those same records.
+        """
+        if self.env.user.has_group("base.group_user") or list(specification) != ["display_name"]:
+            return super().web_name_search(name, specification, domain=domain, operator=operator, limit=limit)
+        records = self.browse([record_id for record_id, _name in self.name_search(name, domain, operator, limit)])
+        formatted = records.sudo().with_context(formatted_display_name=True)
+        return [
+            {
+                "id": record.id,
+                "display_name": record.display_name,
+                "__formatted_display_name": formatted_record.display_name,
+            }
+            for record, formatted_record in zip(records, formatted)
+        ]


### PR DESCRIPTION
A distributor can not pick a customer on a sale order: the dropdown comes back empty and the request fails with

```
John Portal Advanced (id=8) doesn't have 'read' access to: Contact (res.partner)
```

On top of the display name, `web_name_search` asks for a formatted one (`web/models/models.py`):

```python
'__formatted_display_name': record.with_context(formatted_display_name=True).display_name,
```

and computing that reads the parent without sudo (`base/models/res_partner.py`):

```python
if partner.parent_id or partner.company_name:
    name = (f"{partner.company_name or partner.parent_id.name} \t " ...)
```

A portal user can be allowed to read a contact and not its parent — a distributor reads *Odoo by ADHOC, Soporte ADHOC* but not *Odoo by ADHOC* — and then the **whole search** fails instead of returning what it can read. The plain display name works because it uses the stored complete name.

Only the label formatting is done as superuser. The search itself still runs as the user, so record rules keep deciding which contacts show up, and the parent name is already part of the display name of those same records — nothing new is exposed.

## How it was found

Reproduced against the live runbot build of [ingadhoc/demo#342](https://github.com/ingadhoc/demo/pull/342), logged in as the distributor:

```
web_name_search("John") -> ok, 1 result
web_name_search("a")    -> AccessError
```

## Test plan

- As a distributor, create a sale order and open the customer dropdown: contacts are listed and one can be picked.
- As an internal user, the dropdown is unchanged (the override only applies to non internal users).

## Worth knowing

This is not specific to distributors: it hits any portal user with backend access whose visible contacts have a parent they can not read. If you prefer, it belongs in `portal_backend` rather than here.