### PR TITLE
[FIX] sale_loyalty_ux: clear and translatable message when the sale domain does not match

### DIFF
--- a/sale_loyalty_ux/i18n/es.po
+++ b/sale_loyalty_ux/i18n/es.po
@@ -26,6 +26,23 @@ msgid "Loyalty Program"
 msgstr "Programa de fidelización"
 
 #. module: sale_loyalty_ux
+#: model:ir.model.fields,field_description:sale_loyalty_ux.field_loyalty_program__not_applicable_message
+#: model_terms:ir.ui.view,arch_db:sale_loyalty_ux.loyalty_program_view_form
+msgid "Message When the Promotion Does Not Apply"
+msgstr "Mensaje cuando no aplica la promoción"
+
+#. module: sale_loyalty_ux
+#: model:ir.model.fields,help:sale_loyalty_ux.field_loyalty_program__not_applicable_message
+msgid ""
+"Message shown to the user when the sales order does not match the sales "
+"domain. Use it to explain why the program does not apply and what to do to "
+"make it apply. If empty, a generic message is used."
+msgstr ""
+"Mensaje que se le muestra al usuario cuando el pedido de venta no cumple con "
+"el dominio de venta. Sirve para explicar por qué no aplica el programa y qué "
+"debe hacer para que aplique. Si está vacío, se muestra un mensaje genérico."
+
+#. module: sale_loyalty_ux
 #: model:ir.model.fields,field_description:sale_loyalty_ux.field_loyalty_program__sale_domain
 msgid "Sale Domain"
 msgstr "Dominio de venta "
@@ -39,3 +56,18 @@ msgstr "Pedido de venta"
 #: model_terms:ir.ui.view,arch_db:sale_loyalty_ux.loyalty_program_view_form
 msgid "Sales domain"
 msgstr "Dominio de venta"
+
+#. module: sale_loyalty_ux
+#. odoo-python
+#: code:addons/sale_loyalty_ux/models/sale_order.py:0
+msgid ""
+"This promotion cannot be applied because this sales order does not meet the "
+"conditions required by the program \"%(program)s\"."
+msgstr ""
+"Esta promoción no puede aplicarse porque el pedido de venta no cumple con "
+"las condiciones requeridas por el programa \"%(program)s\"."
+
+#. module: sale_loyalty_ux
+#: model_terms:ir.ui.view,arch_db:sale_loyalty_ux.loyalty_program_view_form
+msgid "e.g. You must be registered to use this coupon."
+msgstr "ej. Debe estar registrado para usar este cupón."

--- a/sale_loyalty_ux/models/loyalty_program.py
+++ b/sale_loyalty_ux/models/loyalty_program.py
@@ -12,6 +12,13 @@ class LoyaltyProgram(models.Model):
     _inherit = "loyalty.program"
 
     sale_domain = fields.Char(default="[]")
+    not_applicable_message = fields.Char(
+        string="Message When the Promotion Does Not Apply",
+        translate=True,
+        help="Message shown to the user when the sales order does not match the sales domain. "
+        "Use it to explain why the program does not apply and what to do to make it apply. "
+        "If empty, a generic message is used.",
+    )
 
     def _get_valid_sale_order(self):
         domain = []

--- a/sale_loyalty_ux/models/sale_order.py
+++ b/sale_loyalty_ux/models/sale_order.py
@@ -2,7 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import models
+from odoo import _, models
 
 
 class SaleOrder(models.Model):
@@ -14,5 +14,12 @@ class SaleOrder(models.Model):
             domain = r._get_valid_sale_order()
             if not res[r].get("error") and domain:
                 if self not in self.env["sale.order"].search(domain):
-                    res[r] = {"error": "SaleOrder not matching"}
+                    res[r] = {
+                        "error": r.not_applicable_message
+                        or _(
+                            "This promotion cannot be applied because this sales order does not meet"
+                            ' the conditions required by the program "%(program)s".',
+                            program=r.name,
+                        )
+                    }
         return res

--- a/sale_loyalty_ux/views/loyalty_program_views.xml
+++ b/sale_loyalty_ux/views/loyalty_program_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <field name="date_to" position="after">
                  <field name="sale_domain" string="Sales domain" widget="domain" options="{'model': 'sale.order', 'in_dialog': true}"/>
+                 <field name="not_applicable_message" placeholder="e.g. You must be registered to use this coupon." invisible="not sale_domain or sale_domain == '[]'"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
## Problem

`sale_loyalty_ux` rejects a loyalty/promotion program when the sales order does not match the program's sale domain, and it did so with a hardcoded `"SaleOrder not matching"` string. That string is returned as the `error` of `_program_check_compute_points`, so it reaches the user verbatim: the "Enter promo code" dialog in the backend and the discount field in the eCommerce cart. It is in English regardless of the user language, and it says nothing about why the program was rejected or what to do about it.

For comparison, core `sale_loyalty` returns proper translatable messages for the other rejection paths ("This code is invalid (%s).", "A minimum of ... should be purchased ...").

## Changes

- `models/sale_order.py`: the error is now built with `_()` and mentions the program name.
- `models/loyalty_program.py`: new `sale_domain_error_message` field (translatable). The actual reason for the rejection depends on the domain each program configures, so the generic message cannot state it; this lets the program define its own text (e.g. "You must be registered to use this coupon"). Falls back to the generic message when empty.
- `views/loyalty_program_views.xml`: the field is shown next to `sale_domain`, only when a domain is set.
- `i18n/es.po`: Spanish translations for the new terms.

No manifest version bump, no migration needed (new optional field).

## Test plan

On a database with `sale_loyalty_ux` installed:

1. Create a promotion program with a code trigger and a `Sales domain` that the order cannot match.
2. Apply the code on a quotation -> the dialog now shows a full sentence naming the program instead of `SaleOrder not matching`, translated when the user language is Spanish.
3. Set `Sales domain message` on the program -> that text is shown instead.
4. Clear the domain -> the reward is applied as before.
5. Apply a non-existent code -> core message ("This code is invalid (...)") is unchanged.

Steps 1-5 were run through `odoo shell` on an 18.0 database with `en_US` and `es_AR` installed.