### PR TITLE
[FIX] sale_gathering_automation: do not skip invoicing when confirm returns an action

### DIFF
--- a/sale_gathering_automation/models/sale_order.py
+++ b/sale_gathering_automation/models/sale_order.py
@@ -74,10 +74,15 @@ class SaleOrder(models.Model):
 
     def action_confirm(self):
         res = super().action_confirm()
-        if isinstance(res, bool) and res:
-            for order in self.filtered(
-                lambda x: x.is_gathering and x.type_id.invoicing_atomation != "none" and not x.has_gathering_invoice
-            ):
+        # res puede ser una acción y no solo True: lo que define si facturamos es el estado del pedido
+        orders_to_invoice = self.filtered(
+            lambda x: x.state == "sale"
+            and x.is_gathering
+            and x.type_id.invoicing_atomation != "none"
+            and not x.has_gathering_invoice
+        )
+        if orders_to_invoice:
+            for order in orders_to_invoice:
                 advance_payment_wizard = (
                     self.env["sale.advance.payment.inv"]
                     .with_context(first_gathering_invoice=True)

--- a/sale_gathering_automation/tests/__init__.py
+++ b/sale_gathering_automation/tests/__init__.py
@@ -1,0 +1,6 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+
+from . import test_gathering_invoice_on_confirm

--- a/sale_gathering_automation/tests/test_gathering_invoice_on_confirm.py
+++ b/sale_gathering_automation/tests/test_gathering_invoice_on_confirm.py
@@ -1,0 +1,83 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from unittest.mock import patch
+
+from odoo.tests.common import TransactionCase
+
+
+class TestGatheringInvoiceOnConfirm(TransactionCase):
+    """Si la cadena de ``action_confirm`` devuelve una acción en vez de ``True``,
+    la factura de acopio se tiene que crear igual (ticket 124899)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+        cls.partner = cls.env["res.partner"].create({"name": "Cliente acopio"})
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Producto acopio",
+                "type": "consu",
+                "list_price": 100.0,
+            }
+        )
+        cls.sale_type = cls.env["sale.order.type"].create(
+            {
+                "name": "Tipo acopio test",
+                "picking_atomation": "validate_no_force",
+                "invoicing_atomation": "create_invoice",
+                "warehouse_id": cls.warehouse.id,
+            }
+        )
+        if "exception.rule" in cls.env:
+            cls.env["exception.rule"].search([("model", "in", ("sale.order", "sale.order.line"))]).write(
+                {"active": False}
+            )
+
+    def _create_gathering_order(self):
+        return self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "type_id": self.sale_type.id,
+                "warehouse_id": self.warehouse.id,
+                "is_gathering": True,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_uom_qty": 10.0,
+                            "initial_qty_gathered": 10.0,
+                            "price_unit": 100.0,
+                        },
+                    )
+                ],
+            }
+        )
+
+    def _confirm_returning(self, order, picking_automation_result):
+        """Confirma la venta forzando lo que devuelve la automatización de entregas,
+        que es lo que termina devolviendo la cadena de ``action_confirm``."""
+        with patch.object(type(order), "run_picking_automation", return_value=picking_automation_result):
+            return order.action_confirm()
+
+    def test_gathering_invoiced_when_confirm_returns_an_action(self):
+        # El caso del ticket: la cadena devuelve la acción de impresión de las
+        # entregas validadas en vez de True.
+        print_action = {"type": "ir.actions.client", "tag": "do_multi_print", "params": {"reports": []}}
+        order = self._create_gathering_order()
+        self._confirm_returning(order, print_action)
+        self.assertEqual(order.state, "sale", "La venta no quedó confirmada: la automatización no corrió.")
+        self.assertTrue(
+            order.has_gathering_invoice,
+            "La factura de anticipo del acopio se tiene que crear igual con una acción de por medio.",
+        )
+
+    def test_gathering_invoiced_when_confirm_returns_true(self):
+        order = self._create_gathering_order()
+        res = self._confirm_returning(order, True)
+        self.assertIs(res, True)
+        self.assertTrue(order.has_gathering_invoice)


### PR DESCRIPTION
## Problema

`action_confirm` decide si corre la automatización de facturación mirando la **forma** del retorno de la cadena (`isinstance(res, bool) and res`). Cuando un módulo de arriba devuelve una acción en lugar de `True` — por ejemplo `sale_order_type_automation` devolviendo la acción de impresión de las entregas que valida (#1807) — la factura de anticipo del gathering **no se crea y no salta ningún error**.

## Cambio

La condición pasa a ser el estado del pedido (`state == "sale"`), que es lo que realmente importa: si la confirmación quedó trabada (ej. `sale_exception` devuelve su popup) el pedido no llega a `sale` y la automatización se saltea igual que antes; y cualquier otra acción que devuelva la cadena deja de interferir.

Dejo el `if orders_to_invoice:` sobre el `for` para no re-indentar el cuerpo del método y que el diff quede legible.

## Test plan

Sin cobertura automática nueva: reproducirlo pide un tipo de operación con impresión automática al validar, más la automatización de entregas. Manual:

- Pedido gathering con tipo de venta con `invoicing_atomation` distinto de `none` y automatización de entregas, y tipo de operación con "imprimir remito al validar" → al confirmar se crea la factura de anticipo (antes no se creaba) y sigue saliendo la impresión.
- Con `sale_exception` bloqueando la confirmación, el pedido queda sin confirmar y sin factura, igual que antes.
- Sin nada que imprimir, el comportamiento no cambia.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/124899
