### PR TITLE
[FIX] sale_order_type_automation: register automatic payment on the invoice company

### DIFF
--- a/sale_order_type_automation/models/account_move.py
+++ b/sale_order_type_automation/models/account_move.py
@@ -19,13 +19,23 @@ class AccountMove(models.Model):
             # refunds move the money on the opposite direction of the document they fix,
             # otherwise a customer refund would be registered as an inbound receipt
             "payment_type": "inbound" if invoice.is_inbound() else "outbound",
+            # the payment must live in the invoice company (a branch may invoice while the
+            # shared payment journal belongs to the parent). Company consistency checks use
+            # parent_of semantics, so a payment on the branch can still use the parent journal,
+            # but a payment left on the journal's parent company can't reference the branch lines
+            "company_id": invoice.company_id.id,
             "journal_id": payment_journal.id,
             "date": fields.Date.context_today(self),
             "currency_id": invoice.currency_id.id,
         }
 
     def _register_payment_invoice(self, invoice, payment_journal):
-        payment = self.env["account.payment"].create(self._prepare_dict_account_payment(invoice, payment_journal))
+        # resolve company-dependent defaults/computes against the invoice company (branch)
+        payment = (
+            self.env["account.payment"]
+            .with_company(invoice.company_id)
+            .create(self._prepare_dict_account_payment(invoice, payment_journal))
+        )
         payment.action_post()
 
         domain = [

--- a/sale_order_type_automation/tests/test_sale_order_type_automation.py
+++ b/sale_order_type_automation/tests/test_sale_order_type_automation.py
@@ -111,6 +111,26 @@ class TestSaleOrderTypeAutomation(TransactionCase):
                 }
             )
 
+    def test_prepare_payment_uses_invoice_company(self):
+        # regression: the payment must be built on the invoice company. On a branch that
+        # invoices while the payment journal belongs to the parent, leaving the payment on
+        # the journal's company raised a cross-company error (parent_of consistency check).
+        self.sale_type.write(
+            {
+                "invoicing_atomation": "validate_invoice",
+                "journal_id": self.invoice_journal.id,
+                "picking_atomation": "none",
+                "invoice_validate_domain": False,
+            }
+        )
+        order = self._create_order()
+        order.with_context(ignore_exception=True).action_confirm()
+        invoice = order.invoice_ids
+
+        vals = invoice._prepare_dict_account_payment(invoice, self.invoice_journal)
+
+        self.assertEqual(vals["company_id"], invoice.company_id.id)
+
     def test_validate_payment_automation_accepts_valid_payment_journal(self):
         if not self.payment_journal:
             self.skipTest("No manual payment journal available for current company")


### PR DESCRIPTION
When a branch company issues the invoice while the automatic payment journal belongs to the parent company, registering the payment automatically failed with a cross-company error:

> "Payment draft" belongs to company "<parent>" while "To Pay Journal Items" (to_pay_move_line_ids) belongs to another company.

### Root cause
`_register_payment_invoice` created the `account.payment` without a company, so it stayed on the payment journal company (the parent). The company consistency check on `to_pay_move_line_ids` uses `parent_of` semantics: a payment on the parent company cannot reference invoice lines belonging to a branch (a descendant). Registering the payment manually worked because it runs in the invoice (branch) company context.

### Fix
Build the automatic payment on the invoice company:
- `_prepare_dict_account_payment` now sets `company_id` = `invoice.company_id`.
- `_register_payment_invoice` creates the payment `with_company(invoice.company_id)`.

The shared parent journal is still valid (a branch may use the parent journal via `parent_of`), and the invoice lines now match the payment company, so the consistency check passes.

Added a regression test asserting the payment dict carries the invoice company.

Ticket: #125414