### PR TITLE
[IMP] sale_barcode: add packaging barcodes and keep scanned quantities whole

### DIFF
--- a/sale_barcode/models/sale_order.py
+++ b/sale_barcode/models/sale_order.py
@@ -15,9 +15,11 @@ class SaleOrder(models.Model):
             return
 
         # Handle products only
-        product = self.env["product.product"].search([("barcode", "=", barcode)])
+        product = self.env["product.product"].search([("barcode", "=", barcode)], limit=1)
         if product:
             self._add_product(product)
+        elif packaging := self._get_packaging_from_barcode(barcode):
+            self._add_product(packaging.product_id, uom=packaging.uom_id)
         else:
             return {
                 "warning": {
@@ -27,17 +29,42 @@ class SaleOrder(models.Model):
                 }
             }
 
-    def _add_product(self, product, qty=1.0):
+    def _get_packaging_from_barcode(self, barcode):
+        """Barcodes are unique across products and packagings, so a barcode that
+        matches no product may still be one of a product packaging."""
+        return self.env["product.uom"].search([("barcode", "=", barcode)], limit=1)
+
+    def _add_product(self, product, qty=1.0, uom=None):
+        uom = uom or product.uom_id
+        if uom not in product.product_tmpl_id._get_available_uoms():
+            # the packaging is not sellable for this product, fall back to its unit
+            qty = uom._compute_quantity(qty, product.uom_id)
+            uom = product.uom_id
         corresponding_line = self.order_line.filtered(lambda x: x.product_id == product)
         if corresponding_line:
             # If multiple lines exist, increment the first one
-            corresponding_line[0].product_uom_qty += qty
+            line = corresponding_line[0]
+            line.product_uom_qty += self._get_scanned_qty(line, qty, uom)
         else:
             self.order_line.new(
                 {
                     "product_id": product.id,
+                    "product_uom_id": uom.id,
                     "product_uom_qty": qty,
                     "order_id": self.id,
                 }
             )
         return True
+
+    def _get_scanned_qty(self, line, qty, uom):
+        """Quantity to add to an existing line, expressed in the unit of that line.
+
+        Scanning the packaging of a product sold by unit adds its whole content,
+        and scanning a unit of a product sold by packaging adds a whole packaging
+        instead of a fraction of one.
+        """
+        line_uom = line.product_uom_id
+        if line_uom == uom:
+            return qty
+        line_qty = uom._compute_quantity(qty, line_uom, round=False)
+        return 1.0 if line_uom.compare(line_qty, 1.0) < 0 else line_qty

--- a/sale_barcode/tests/__init__.py
+++ b/sale_barcode/tests/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import test_sale_barcode

--- a/sale_barcode/tests/test_sale_barcode.py
+++ b/sale_barcode/tests/test_sale_barcode.py
@@ -1,0 +1,98 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests import Form, TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSaleBarcode(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.user.group_ids += cls.env.ref("uom.group_uom")
+        cls.unit = cls.env.ref("uom.product_uom_unit")
+        cls.packaging_uom = cls.env["uom.uom"].create(
+            {
+                "name": "Pack of 12",
+                "relative_factor": 12.0,
+                "relative_uom_id": cls.unit.id,
+            }
+        )
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Scannable product",
+                "list_price": 100.0,
+                "barcode": "PRODUCT_BARCODE",
+                "uom_id": cls.unit.id,
+                "uom_ids": [(6, 0, cls.packaging_uom.ids)],
+            }
+        )
+        cls.env["product.uom"].create(
+            {
+                "product_id": cls.product.id,
+                "uom_id": cls.packaging_uom.id,
+                "barcode": "PACKAGING_BARCODE",
+            }
+        )
+        cls.partner = cls.env["res.partner"].create({"name": "Scannable partner"})
+
+    def _scan(self, *barcodes):
+        """Return the order lines resulting from scanning barcodes on a new order."""
+        order_form = Form(self.env["sale.order"])
+        order_form.partner_id = self.partner
+        for barcode in barcodes:
+            order_form._barcode_scanned = barcode
+        return order_form.save().order_line
+
+    def test_scan_product(self):
+        lines = self._scan(*["PRODUCT_BARCODE"] * 15)
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines.product_uom_qty, 15.0)
+        self.assertEqual(lines.product_uom_id, self.unit)
+
+    def test_scan_packaging(self):
+        lines = self._scan(*["PACKAGING_BARCODE"] * 3)
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines.product_uom_qty, 3.0)
+        self.assertEqual(lines.product_uom_id, self.packaging_uom)
+
+    def test_scan_packaging_on_line_sold_by_unit(self):
+        """The packaging content is added to the line, in the unit of that line."""
+        lines = self._scan("PRODUCT_BARCODE", "PRODUCT_BARCODE", "PACKAGING_BARCODE")
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines.product_uom_qty, 14.0)
+        self.assertEqual(lines.product_uom_id, self.unit)
+
+    def test_scan_product_on_line_sold_by_packaging(self):
+        """A single unit adds a whole packaging instead of a fraction of one."""
+        lines = self._scan("PACKAGING_BARCODE", "PRODUCT_BARCODE")
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines.product_uom_qty, 2.0)
+        self.assertEqual(lines.product_uom_id, self.packaging_uom)
+
+    def test_scan_product_on_line_with_packaging_set_manually(self):
+        order_form = Form(self.env["sale.order"])
+        order_form.partner_id = self.partner
+        order_form._barcode_scanned = "PRODUCT_BARCODE"
+        with order_form.order_line.edit(0) as line:
+            line.product_uom_id = self.packaging_uom
+            line.product_uom_qty = 1.0
+        order_form._barcode_scanned = "PRODUCT_BARCODE"
+        lines = order_form.save().order_line
+        self.assertEqual(lines.product_uom_qty, 2.0)
+        self.assertEqual(lines.product_uom_id, self.packaging_uom)
+
+    def test_scan_packaging_not_sellable(self):
+        """A packaging not available for sale falls back to the product unit."""
+        self.product.uom_ids = [(5, 0, 0)]
+        lines = self._scan("PACKAGING_BARCODE")
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines.product_uom_qty, 12.0)
+        self.assertEqual(lines.product_uom_id, self.unit)
+
+    def test_scan_unknown_barcode(self):
+        order = self.env["sale.order"].new({"partner_id": self.partner.id})
+        result = order.on_barcode_scanned("UNKNOWN_BARCODE")
+        self.assertIn("warning", result)
+        self.assertFalse(order.order_line)


### PR DESCRIPTION
`sale_barcode` did not handle packagings. In 19.0 packagings are units of measure (`product.template.uom_ids`, with `product.uom` holding their barcode), and scanning one was rejected as an unknown barcode.

### What changes

- **Packaging barcodes are recognized.** Barcodes are unique across products and packagings, so a barcode matching no product is looked up on `product.uom` — same criterion `stock_barcode` uses. Scanning one adds the product on a line expressed in that packaging unit.
- **Scanned quantities stay whole.** On an existing line the quantity is expressed in the unit of that line: scanning a packaging on a line sold by unit adds its whole content, and scanning a unit on a line sold by packaging adds a whole packaging instead of a fraction of one.
- A packaging not available for sale on the product falls back to the product unit.
- Product lookup now uses `limit=1`; a duplicated barcode used to return a multi-record set.

### Test plan

`sale_barcode/tests/test_sale_barcode.py` drives the real `_barcode_scanned` onchange through `Form`. On a product sold by unit with a `Pack of 12` packaging:

| Scans | Result |
|---|---|
| 15 × unit | `15.00 Units` |
| 3 × packaging | `3.00 Pack of 12` |
| 2 × unit, then packaging | `14.00 Units` |
| packaging, then unit | `2.00 Pack of 12` |
| unit, packaging set by hand on the line, then unit | `2.00 Pack of 12` |
| packaging, with the packaging removed from the product | `12.00 Units` |
| unknown barcode | warning, no line |

Also checked in the browser on a fresh 19.0 database: quantities and the packaging unit hold after saving, and the unit price converts per unit of measure.

Task: /odoo/project.task/72469
