### PR TITLE
[IMP] sale_barcode: document the packaging circuit and its known limitation

### DIFF
--- a/sale_barcode/README.rst
+++ b/sale_barcode/README.rst
@@ -39,6 +39,40 @@ To use this module, you need to:
 
 #. To view Sale Orders Lines, go to: Sales/Sales/Sale Lines
 
+Packagings
+----------
+
+A packaging is a unit of measure of the product, listed on its *Sales* tab
+under *Packagings*, and its barcode is set on that unit of measure (*Packaging
+Barcodes*). Both barcodes are taken into account when scanning on a sale order:
+
+* Scanning the product barcode adds one unit.
+* Scanning a packaging barcode adds one packaging, on a line expressed in that
+  packaging unit.
+
+The quantity of an existing line is always expressed in the unit of that line,
+so scanning a packaging on a line sold by unit adds its whole content.
+
+Known limitations
+=================
+
+Scanning a unit on a line sold by packaging adds a whole packaging
+------------------------------------------------------------------
+
+Scanning a packaging of 6 units and then scanning the same product by unit
+leaves the line at 2 packagings, that is 12 units, instead of the 7 units that
+were actually scanned. The line already exists in the packaging unit, and the
+scan is added in that unit.
+
+Adding the exact amount instead would put a fraction of a packaging on the
+line, and a decimal quantity where the salesperson counted whole items. So
+selling a packaging plus some loose units of the same product needs the loose
+units to be set by hand on their own line.
+
+We decided to keep the current behaviour for now, rather than add the
+complexity of splitting a line per unit of measure, because we do not expect
+this to be a common case.
+
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
    :target: http://runbot.adhoc.com.ar/


### PR DESCRIPTION
Documents the packaging circuit in the module README, so the behaviour and the case we analysed and chose not to cover are written down where the module lives.

### What it documents

- Where a packaging lives in 19.0 (a unit of measure on the product's *Sales* tab, with its barcode under *Packaging Barcodes*) and what each barcode does when scanned on a sale order.
- That the quantity of an existing line is always expressed in the unit of that line.

### The known limitation

Scanning a packaging of 6 units and then the same product by unit leaves the line at 2 packagings — 12 units — instead of the 7 that were scanned, because the scan is added in the unit of the existing line.

Adding the exact amount instead would put a fraction of a packaging on the line, and a decimal quantity where the salesperson counted whole items. Selling a packaging plus some loose units of the same product therefore needs the loose units set by hand on their own line.

Kept as is for now rather than splitting a line per unit of measure, since we do not expect it to be a common case.

### Notes

Documentation only, no code. Complements #1823, which adds the packaging barcode handling described here.

Task: /odoo/project.task/72469
