### PR TITLE
[ADD] pos_event_ux: prevent overbooking event tickets from the PoS

### DIFF
--- a/pos_event_ux/README.rst
+++ b/pos_event_ux/README.rst
@@ -1,0 +1,74 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-LGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/lgpl
+   :alt: License: LGPL-3
+
+======================
+Point of Sale Event UX
+======================
+
+Prevents selling more event tickets than the event capacity from the Point of Sale.
+
+On Odoo 18 the standard capacity guard never runs on the PoS flow, so an order can push an event past ``seats_max`` with no error at all. This module re-runs the capacity check on the affected events and tickets when the order is paid, raising a ``ValidationError`` on overbooking.
+
+Note: the check runs at synchronization time, after the cashier took the money. In that case the order fails to sync and no ticket is issued.
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Only need to install the module
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Nothing to configure
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Nothing special, it works automatically when selling event tickets from the PoS
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: http://runbot.adhoc.com.ar/
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/ingadhoc/sale/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* |company| |icon|
+
+Contributors
+------------
+
+Maintainer
+----------
+
+|company_logo|
+
+This module is maintained by the |company|.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/pos_event_ux/__init__.py
+++ b/pos_event_ux/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/pos_event_ux/__manifest__.py
+++ b/pos_event_ux/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    "name": "Point of Sale Event UX",
+    "version": "18.0.1.0.0",
+    "category": "Point of Sale",
+    "author": "ADHOC SA",
+    "depends": [
+        "pos_event_sale",
+    ],
+    "data": [],
+    "installable": True,
+    "auto_install": False,
+    "license": "LGPL-3",
+}

--- a/pos_event_ux/models/__init__.py
+++ b/pos_event_ux/models/__init__.py
@@ -1,0 +1,1 @@
+from . import pos_order

--- a/pos_event_ux/models/pos_order.py
+++ b/pos_event_ux/models/pos_order.py
@@ -1,0 +1,15 @@
+from odoo import models
+
+
+class PosOrder(models.Model):
+    _inherit = "pos.order"
+
+    def action_pos_order_paid(self):
+        res = super().action_pos_order_paid()
+        registrations = self.lines.event_registration_ids
+        if registrations:
+            self.env.flush_all()
+            for records in (registrations.event_id, registrations.event_ticket_id):
+                records.invalidate_recordset(["seats_reserved", "seats_available", "seats_used", "seats_taken"])
+                records._check_seats_availability()
+        return res


### PR DESCRIPTION
## What

New module `pos_event_ux`: re-checks event capacity when a PoS order is paid, so the box office cannot sell more tickets than `seats_max`.

## Why

On 18.0 the capacity guard never runs on the PoS flow, and an order that exceeds the limit goes through with no error at all. It is **not** a race between concurrent operations — it happens inside a single transaction and reproduces consistently. The excess is not capped at one seat: it equals `order quantity - free seats`, so an order of 4 tickets with 1 seat left lets 3 extra attendees in.

Why the core guard misses it:

- `point_of_sale/models/pos_order.py` — `_process_order` forces the order to `draft` on create.
- `pos_event_sale/models/event_registration.py` — the registration `state` depends on `pos_order_id.state`, so registrations are born `draft`.
- `event/models/event_registration.py` — the `@api.constrains` only looks at registrations in state `open`/`done`, so at create time it validates an empty recordset. The only remaining checkpoint is the flip to `paid`.
- `event/models/event_event.py` — on that flip the constraint runs inside the recomputation of `event.registration.state`, and `_compute_seats` hands it zeroed values (`seats_taken=0`, `seats_available=0`) even when the table already holds confirmed registrations. The guard raises on `seats_available < minimal_availability`, whose default is `0`, so a `0` passes.

The defect is upstream (`event`, `pos_event`, `pos_event_sale`); no Adhoc code is involved in that path. This module is a mitigation while that is sorted out.

## How

`action_pos_order_paid` re-runs `_check_seats_availability()` on the affected events and tickets, after flushing the recomputed states and invalidating the seat computations, so the count sees the real numbers.

## Test plan

Scenario: event with `seats_max`, N-1 seats already confirmed, one **paid** PoS order sent through `pos.order.sync_from_ui`.

| Case | Expected | Result |
|---|---|---|
| 1 seat left, order of 2 | blocked | blocked, sale rolled back |
| 1 seat left, order of 4 | blocked | blocked, sale rolled back |
| 2 seats left, order of 3 | blocked | blocked, sale rolled back |
| 2 seats left, order of 2 (exact fit) | goes through | `seats_taken=10/10` |
| 5 seats left, order of 1 | goes through | ok |
| 10 seats left, order of 10 (fills exactly) | goes through | `seats_taken=10/10` |
| plain PoS sale, no event | unaffected | order created |

Before the module the same scenario overbooked 10/10 runs with no error; after it, all 10 raise `ValidationError`.

## Known limitation

This blocks the overbooking at synchronisation time, which is *after* the cashier took the money: the order fails to sync and no ticket is issued. Closing that gap needs a capacity check **before** payment, like `website_event_sale` does on the web channel (`_check_seats_availability(minimal_availability=count)`), which `pos_event` does not have.

`auto_install` is left `False` on purpose: enabling it would change selling behaviour on every database with `pos_event_sale` installed without an explicit decision.
