### PR TITLE
[FIX] sale_ux: keep the final invoice balanced when a down payment is deducted

### DIFF
--- a/sale_ux/models/account_move.py
+++ b/sale_ux/models/account_move.py
@@ -2,6 +2,8 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
+from collections import defaultdict
+
 from odoo import api, fields, models
 
 
@@ -12,6 +14,10 @@ class AccountMove(models.Model):
     sale_order_ids = fields.Many2many("sale.order", compute="_compute_sale_orders")
     # en la ui agregamos este que seria mejor a nivel performance
     has_sales = fields.Boolean(string="Has Sales?", compute="_compute_has_sales")
+    # no almacenado: memoiza el calculo por factura, porque
+    # _prepare_product_base_line_for_taxes_computation corre una vez por linea y necesita el
+    # agregado de todas
+    downpayment_base_targets = fields.Json(compute="_compute_downpayment_base_targets", exportable=False)
 
     @api.depends("move_type", "partner_id", "partner_id.lang", "company_id")
     def _compute_narration(self):
@@ -38,3 +44,127 @@ class AccountMove(models.Model):
         (self - moves).has_sales = False
         for rec in moves:
             rec.has_sales = any(line for line in rec.invoice_line_ids.mapped("sale_line_ids"))
+
+    @api.depends(
+        "company_id",
+        "company_id.tax_calculation_rounding_method",
+        "currency_id",
+        "invoice_line_ids.display_type",
+        "invoice_line_ids.is_downpayment",
+        "invoice_line_ids.price_unit",
+        "invoice_line_ids.quantity",
+        "invoice_line_ids.discount",
+        "invoice_line_ids.tax_ids",
+        "invoice_line_ids.account_id",
+        "invoice_line_ids.product_id",
+        "invoice_line_ids.product_uom_id",
+        "invoice_line_ids.sale_line_ids",
+    )
+    def _compute_downpayment_base_targets(self):
+        """Base sin impuestos objetivo de cada linea de producto de una factura que deduce un anticipo.
+
+        El wizard de anticipos redondea el price_unit del anticipo a la moneda una vez por grupo
+        (_prepare_down_payment_lines_values), asi que la factura final tiene que agregar y redondear
+        las lineas de producto con esa misma particion para que la deduccion cancele exacto.
+
+        Cada linea de anticipo de la factura trae la clave de su grupo puesta, asi que la partimos
+        contra ella en lugar de re-derivarla. Un grupo puede tener mas de una linea de anticipo
+        (pasa cuando se anticipo en varias tandas sobre la misma orden), y el objetivo sigue siendo
+        el mismo: el agregado del grupo redondeado una sola vez. Si un grupo no tiene ninguna linea
+        de anticipo que le corresponda, o si el anticipo del grupo quedo repartido en mas de una cuenta,
+        no lo tocamos.
+
+        Devuelve {str(line.id): base} solo para las lineas ajustadas, y vacio cuando no hay nada que
+        corregir.
+        """
+        AccountTax = self.env["account.tax"]
+        for move in self:
+            move.downpayment_base_targets = False
+            if not move.is_sale_document(include_receipts=True):
+                # solo ventas: purchase tambien setea is_downpayment en sus lineas, y ahi la clave
+                # de grupo no aplica (no hay sale_line_ids) ademas de no ser asunto de este modulo
+                continue
+            if move.company_id.tax_calculation_rounding_method != "round_globally":
+                # con round_per_line cada linea ya se redondea sola y el residuo no aparece
+                continue
+            product_lines = move.invoice_line_ids.filtered(lambda line: line.display_type == "product")
+            downpayment_lines = product_lines.filtered("is_downpayment")
+            if not downpayment_lines:
+                continue
+            downpayment_accounts_per_key = defaultdict(set)
+            for line in downpayment_lines:
+                key = move._get_downpayment_group_key(line)
+                downpayment_accounts_per_key[key].add(line.account_id.id)
+            currency = move.currency_id or move.company_id.currency_id
+            # sin la clave de contexto el override devuelve la base cruda, que es lo que agregamos
+            move_without_targets = move.with_context(sale_ux_downpayment_base_targets=False)
+            raw_amounts_per_group = defaultdict(dict)
+            for line in product_lines - downpayment_lines:
+                base_line = move_without_targets._prepare_product_base_line_for_taxes_computation(line)
+                AccountTax._add_tax_details_in_base_line(base_line, move.company_id)
+                key = move._get_downpayment_group_key(line)
+                raw_amounts_per_group[key][str(line.id)] = base_line["tax_details"]["raw_total_excluded_currency"]
+            targets = {}
+            for key, raw_amounts in raw_amounts_per_group.items():
+                accounts = downpayment_accounts_per_key.get(key)
+                if not accounts or len(accounts) > 1:
+                    # sin un anticipo deducido para ese grupo no sabemos contra que cancela, y si el
+                    # anticipo quedo repartido en mas de una cuenta la particion no es la nuestra: en
+                    # los dos casos dejamos el redondeo estandar antes que arriesgar otro descuadre
+                    continue
+                rounded = {line_key: currency.round(amount) for line_key, amount in raw_amounts.items()}
+                # el grupo se redondea una sola vez, como lo hizo el anticipo, y la diferencia la
+                # absorbe la linea mas grande (mismo criterio que usa Odoo para distribuir deltas)
+                delta = currency.round(sum(raw_amounts.values())) - sum(rounded.values())
+                if not currency.is_zero(delta):
+                    biggest = max(raw_amounts, key=lambda line_key: abs(raw_amounts[line_key]))
+                    rounded[biggest] = currency.round(rounded[biggest] + delta)
+                targets.update(rounded)
+            move.downpayment_base_targets = targets
+
+    def _get_downpayment_group_key(self, line):
+        """Grupo con el que el wizard de anticipos redondeo la linea.
+
+        Espeja la parte de _prepare_down_payment_lines_values que se puede reproducir sobre la
+        factura: la orden y los impuestos (jerarquia aplanada y sin los fijos, que el anticipo no
+        arrastra). El wizard tambien agrupa por cuenta, pero la que termina en la linea de anticipo
+        no se puede re-derivar de forma confiable desde el producto, asi que en lugar de adivinarla
+        se controla aparte que las lineas de anticipo del grupo compartan una sola.
+        """
+        self.ensure_one()
+        taxes = line.tax_ids.flatten_taxes_hierarchy()
+        fixed_taxes = taxes.filtered(lambda tax: tax.amount_type == "fixed")
+        return (
+            tuple(sorted(line.sale_line_ids.order_id.ids)),
+            tuple(sorted((taxes - fixed_taxes).ids)),
+        )
+
+    # El core resuelve esto de forma nativa a partir de la 18.3: el motor de impuestos gano manejo
+    # propio de anticipos (account.tax._prepare_down_payment_lines /
+    # _prepare_base_lines_for_down_payment, verificado en 19.0) y setea el mismo
+    # manual_total_excluded_currency que usamos aca. Este override es solo para 18.0 y NO tiene que
+    # portearse a 19.0: ahi pisaria el valor que calcula el core.
+    def _get_rounded_base_and_tax_lines(self, round_from_tax_lines=True):
+        # El ajuste se activa solo por este camino, que es el que produce los importes contables de
+        # la factura y sus totales. Los demas consumidores del hook por linea tienen que seguir
+        # viendo la base cruda: el descuento por pronto pago escala el price_unit despues de armar
+        # la base line, y varios EDI agregan un subconjunto de lineas, asi que una base fijada de
+        # todo el grupo les daria un importe equivocado.
+        move = self.with_context(sale_ux_downpayment_base_targets=True)
+        return super(AccountMove, move)._get_rounded_base_and_tax_lines(round_from_tax_lines=round_from_tax_lines)
+
+    def _prepare_product_base_line_for_taxes_computation(self, product_line):
+        base_line = super()._prepare_product_base_line_for_taxes_computation(product_line)
+        if not self.env.context.get("sale_ux_downpayment_base_targets"):
+            return base_line
+        target = (self.downpayment_base_targets or {}).get(str(product_line.id))
+        if target is not None:
+            # Con round_globally la linea de anticipo (ya redondeada cuando se facturo) se agrega
+            # junto a las lineas de producto (en crudo), y el residuo sub-centavo del conjunto se
+            # amplifica a un centavo entero: la factura final queda descuadrada contra la orden y,
+            # si el anticipo la cubre entera, hasta se da vuelta a nota de credito. Apuntamos la
+            # base del grupo al mismo numero que uso el anticipo. Eso corre el total_excluded de la
+            # linea (y con el su saldo contable) en ese centavo, que es justamente el arreglo;
+            # price_unit, price_subtotal y los importes crudos no se tocan.
+            base_line["manual_total_excluded_currency"] = target
+        return base_line

--- a/sale_ux/tests/__init__.py
+++ b/sale_ux/tests/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import test_downpayment_rounding

--- a/sale_ux/tests/test_downpayment_rounding.py
+++ b/sale_ux/tests/test_downpayment_rounding.py
@@ -1,0 +1,348 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import Command
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestDownpaymentRounding(AccountTestInvoicingCommon):
+    """Facturas finales que deducen un anticipo bajo round_globally.
+
+    Una cantidad decimal puede dejar el subtotal crudo de una linea en medio centavo
+    (0.5 * 1.01 = 0.505), mientras que el anticipo solo pudo facturar el importe ya redondeado.
+    Al agregar ambos lados, ese residuo se amplifica a un centavo entero que descuadra la factura
+    final contra la orden, y cuando el anticipo cubre todo la da vuelta a nota de credito.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.company.tax_calculation_rounding_method = "round_globally"
+        # sale_exception, presente al instalar el stack completo, hace cr.rollback() dentro de
+        # action_confirm cuando detecta una excepcion: en un test eso se lleva puesta la
+        # transaccion entera, no solo la confirmacion. Desactivamos las reglas para que el
+        # escenario sea determinista.
+        if "exception.rule" in cls.env:
+            cls.env["exception.rule"].sudo().search([]).write({"active": False})
+        # 'consu' + invoice_policy 'order' es lo mas robusto en el stack completo: un 'service'
+        # arrastra service_policy / subscription / timesheet y puede dejar la factura final sin
+        # nada facturable. _create_product ya setea las cuentas de ingreso y gasto.
+        cls.product_a_tax = cls._create_product(
+            name="DP rounding tax A", type="consu", invoice_policy="order", taxes_id=cls.tax_sale_a
+        )
+        cls.product_b_tax = cls._create_product(
+            name="DP rounding tax B", type="consu", invoice_policy="order", taxes_id=cls.tax_sale_b
+        )
+
+    def _create_order(self, lines):
+        return self.env["sale.order"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": product.id,
+                            "product_uom_qty": quantity,
+                            "price_unit": price_unit,
+                            "tax_id": [Command.set(product.taxes_id.ids)],
+                        }
+                    )
+                    for product, quantity, price_unit in lines
+                ],
+            }
+        )
+
+    def _invoice_downpayment_and_balance(self, order, percentage):
+        """Factura el anticipo, lo contabiliza y devuelve (anticipo, factura final)."""
+        order.action_confirm()
+        self.assertEqual(order.state, "sale", "la orden tiene que quedar confirmada")
+        self.env["sale.advance.payment.inv"].with_context(
+            active_model="sale.order", active_ids=order.ids, active_id=order.id
+        ).create({"advance_payment_method": "percentage", "amount": percentage}).create_invoices()
+        downpayment = order.invoice_ids
+        downpayment.action_post()
+        return downpayment, order._create_invoices(final=True)
+
+    def _assert_no_spurious_refund(self, final_invoice):
+        self.assertEqual(
+            final_invoice.move_type,
+            "out_invoice",
+            "una factura final totalmente deducida no puede salir como nota de credito",
+        )
+
+    def test_full_downpayment_single_line(self):
+        """Anticipo del 100% sobre una linea con residuo de medio centavo."""
+        order = self._create_order([(self.product_a_tax, 0.5, 1.01)])
+        downpayment, final_invoice = self._invoice_downpayment_and_balance(order, 100)
+
+        self._assert_no_spurious_refund(final_invoice)
+        self.assertAlmostEqual(final_invoice.amount_total, 0.0, places=2)
+        self.assertAlmostEqual(downpayment.amount_total, order.amount_total, places=2)
+
+    def test_full_downpayment_multiple_lines(self):
+        """Varias lineas con residuo: el conjunto se redondea una sola vez, no linea por linea."""
+        order = self._create_order([(self.product_a_tax, 0.5, 1.01)] * 3)
+        downpayment, final_invoice = self._invoice_downpayment_and_balance(order, 100)
+
+        self._assert_no_spurious_refund(final_invoice)
+        self.assertAlmostEqual(final_invoice.amount_total, 0.0, places=2)
+        self.assertAlmostEqual(
+            downpayment.amount_total + final_invoice.amount_total,
+            order.amount_total,
+            places=2,
+            msg="lo facturado no puede diferir del total de la orden",
+        )
+
+    def test_full_downpayment_many_lines(self):
+        """El error crecia con la cantidad de lineas: cinco lineas, cinco residuos."""
+        order = self._create_order([(self.product_a_tax, 0.5, 1.01)] * 5)
+        downpayment, final_invoice = self._invoice_downpayment_and_balance(order, 100)
+
+        self._assert_no_spurious_refund(final_invoice)
+        self.assertAlmostEqual(final_invoice.amount_total, 0.0, places=2)
+        self.assertAlmostEqual(downpayment.amount_total + final_invoice.amount_total, order.amount_total, places=2)
+
+    def test_partial_downpayment_multiple_lines(self):
+        """Anticipo parcial: la factura final cobra el resto exacto, sin centavo de mas."""
+        order = self._create_order([(self.product_a_tax, 0.5, 1.01)] * 3)
+        downpayment, final_invoice = self._invoice_downpayment_and_balance(order, 40)
+
+        self.assertAlmostEqual(
+            downpayment.amount_total + final_invoice.amount_total,
+            order.amount_total,
+            places=2,
+            msg="anticipo + factura final tienen que sumar el total de la orden",
+        )
+
+    def test_full_downpayment_mixed_taxes(self):
+        """Dos impuestos distintos: el anticipo se redondea una vez por combinacion de impuestos.
+
+        La factura final tiene que agregar con esa misma particion. El anticipo puede quedar un
+        centavo arriba del total de la orden (el wizard redondea por grupo y la orden agrega todo
+        junto), pero eso es previo a este arreglo y no depende de la factura final: lo que se
+        verifica aca es que la final cierre en cero y no salga nota de credito.
+        """
+        order = self._create_order([(self.product_a_tax, 0.5, 1.01), (self.product_b_tax, 0.5, 1.01)])
+        downpayment, final_invoice = self._invoice_downpayment_and_balance(order, 100)
+
+        self.assertEqual(len(downpayment.invoice_line_ids.filtered("is_downpayment")), 2)
+        self._assert_no_spurious_refund(final_invoice)
+        self.assertAlmostEqual(final_invoice.amount_total, 0.0, places=2)
+
+    def test_full_downpayment_without_residual(self):
+        """Sin residuo sub-centavo el comportamiento no cambia."""
+        order = self._create_order([(self.product_a_tax, 1.0, 100.0)] * 3)
+        downpayment, final_invoice = self._invoice_downpayment_and_balance(order, 30)
+
+        self.assertAlmostEqual(downpayment.amount_untaxed, 90.0, places=2)
+        self.assertAlmostEqual(final_invoice.amount_untaxed, 210.0, places=2)
+        self.assertAlmostEqual(downpayment.amount_total + final_invoice.amount_total, order.amount_total, places=2)
+
+    def test_round_per_line_is_not_adjusted(self):
+        """Con round_per_line el ajuste no se activa.
+
+        Ese metodo arrastra su propia diferencia de un centavo, por otro camino: el wizard suma los
+        importes crudos y redondea una vez, mientras cada linea de la factura se redondea sola. No
+        se corrige aca porque no produce la nota de credito que motiva este arreglo y tocarlo
+        cambiaria el comportamiento del metodo de redondeo que Odoo usa por default. Lo que se
+        verifica es que el ajuste quede inactivo y que no aparezca una nota de credito.
+        """
+        self.env.company.tax_calculation_rounding_method = "round_per_line"
+        order = self._create_order([(self.product_a_tax, 0.5, 1.01)] * 3)
+        dummy, final_invoice = self._invoice_downpayment_and_balance(order, 100)
+
+        self.assertFalse(final_invoice.downpayment_base_targets)
+        self._assert_no_spurious_refund(final_invoice)
+
+    def test_full_downpayment_with_fixed_tax(self):
+        """Un impuesto fijo en algunas lineas no tiene que partir el grupo.
+
+        El anticipo no arrastra los impuestos fijos, asi que agrupa esas lineas junto con las que
+        solo llevan el impuesto porcentual. Se compara la base sin impuestos porque el impuesto fijo
+        se cobra recien en la factura final.
+        """
+        fixed_tax = self.env["account.tax"].create(
+            {
+                "name": "Fixed sale tax",
+                "type_tax_use": "sale",
+                "amount_type": "fixed",
+                "amount": 1.0,
+                "company_id": self.env.company.id,
+            }
+        )
+        product_with_fixed_tax = self._create_product(
+            name="DP rounding fixed tax",
+            type="consu",
+            invoice_policy="order",
+            taxes_id=self.tax_sale_a + fixed_tax,
+        )
+        order = self._create_order([(self.product_a_tax, 0.5, 1.01), (product_with_fixed_tax, 0.5, 1.01)])
+        downpayment, final_invoice = self._invoice_downpayment_and_balance(order, 50)
+
+        self.assertAlmostEqual(
+            downpayment.amount_untaxed + final_invoice.amount_untaxed,
+            order.amount_untaxed,
+            places=2,
+            msg="la base facturada no puede diferir de la base de la orden",
+        )
+
+    def test_full_downpayment_consolidated_billing(self):
+        """Una sola factura final que deduce un anticipo por cada orden.
+
+        El wizard redondeo cada anticipo contra su propia orden, asi que la particion tiene que
+        incluir la orden: si se agregaran todas las lineas juntas, la deduccion no cancelaria.
+        """
+        orders = self.env["sale.order"]
+        for dummy in range(2):
+            order = self._create_order([(self.product_a_tax, 0.5, 1.01)])
+            order.action_confirm()
+            self.env["sale.advance.payment.inv"].with_context(
+                active_model="sale.order", active_ids=order.ids, active_id=order.id
+            ).create({"advance_payment_method": "percentage", "amount": 100}).create_invoices()
+            order.invoice_ids.action_post()
+            orders |= order
+
+        final_invoice = orders._create_invoices(final=True)
+
+        self.assertEqual(len(final_invoice), 1, "las ordenes del mismo cliente se agrupan en una factura")
+        self.assertEqual(len(final_invoice.invoice_line_ids.filtered("is_downpayment")), 2)
+        self._assert_no_spurious_refund(final_invoice)
+        self.assertAlmostEqual(final_invoice.amount_total, 0.0, places=2)
+
+    def test_full_downpayment_in_two_rounds_with_discount(self):
+        """Residuo por descuento y anticipo cobrado en dos tandas sobre la misma orden.
+
+        Es la forma en que aparece en la practica: el subtotal crudo no cae en medio centavo por una
+        cantidad decimal sino por un descuento (597895.50 con 15% => 508211.175), y la orden puede
+        arrastrar mas de una linea de anticipo del mismo grupo porque se anticipo dos veces. El
+        objetivo del grupo sigue siendo su agregado redondeado una sola vez.
+
+        Con estos importes las dos tandas suman exactamente el agregado redondeado del grupo, asi
+        que la factura final cierra en cero. Cuando no lo hacen, el wizard cobra de mas y la final
+        sale negativa por ese centavo; eso es previo a este ajuste y lo cubre
+        test_downpayment_rounded_up_in_several_rounds. Lo que se verifica en los dos casos es la
+        invariante: lo facturado no puede diferir del total de la orden.
+        """
+        order = self._create_order([(self.product_a_tax, 1.0, 597895.50), (self.product_a_tax, 1.0, 3210000.0)])
+        order.order_line.discount = 15.0
+        order.action_confirm()
+        for dummy in range(2):
+            self.env["sale.advance.payment.inv"].with_context(
+                active_model="sale.order", active_ids=order.ids, active_id=order.id
+            ).create({"advance_payment_method": "percentage", "amount": 50}).create_invoices()
+        downpayments = order.invoice_ids
+        downpayments.action_post()
+        self.assertEqual(len(downpayments.invoice_line_ids.filtered("is_downpayment")), 2)
+
+        final_invoice = order._create_invoices(final=True)
+
+        self._assert_no_spurious_refund(final_invoice)
+        self.assertAlmostEqual(final_invoice.amount_total, 0.0, places=2)
+        self.assertAlmostEqual(
+            sum(downpayments.mapped("amount_total")) + final_invoice.amount_total,
+            order.amount_total,
+            places=2,
+        )
+
+    def test_full_downpayment_with_downpayment_account_configured(self):
+        """Cuenta de anticipo propia en la categoria del producto.
+
+        Asi esta configurado en la practica: la linea de anticipo termina en una cuenta distinta a la
+        de ingresos de la linea de producto que dedujo. La particion no puede depender de re-derivar
+        esa cuenta desde el producto.
+        """
+        downpayment_account = self.env["account.account"].create(
+            {"name": "Anticipos de clientes", "code": "ANT001", "account_type": "liability_current"}
+        )
+        self.product_a_tax.categ_id.property_account_downpayment_categ_id = downpayment_account
+        order = self._create_order([(self.product_a_tax, 0.5, 1.01)])
+        downpayment, final_invoice = self._invoice_downpayment_and_balance(order, 100)
+
+        self.assertEqual(
+            downpayment.invoice_line_ids.filtered("is_downpayment").account_id,
+            downpayment_account,
+            "el anticipo tiene que haber ido a la cuenta configurada en la categoria",
+        )
+        self._assert_no_spurious_refund(final_invoice)
+        self.assertAlmostEqual(final_invoice.amount_total, 0.0, places=2)
+
+    def test_downpayment_rounded_up_in_several_rounds(self):
+        """El wizard puede cobrar de mas al anticipar en tandas, y eso no lo corrige este ajuste.
+
+        Cada tanda redondea su propio importe: dos tandas del 50% sobre 1.01 facturan 0.51 + 0.51 =
+        1.02. La factura final sale negativa por el centavo cobrado de mas, con o sin este ajuste
+        (aca no hay residuo sub-centavo, asi que el target coincide con el importe crudo y el
+        override no cambia nada). Se deja fijado para que se vea que es del wizard y no de este
+        arreglo: lo que se sostiene es que lo facturado siga sumando el total de la orden.
+        """
+        order = self._create_order([(self.product_a_tax, 1.0, 1.01)])
+        order.action_confirm()
+        for dummy in range(2):
+            self.env["sale.advance.payment.inv"].with_context(
+                active_model="sale.order", active_ids=order.ids, active_id=order.id
+            ).create({"advance_payment_method": "percentage", "amount": 50}).create_invoices()
+        downpayments = order.invoice_ids
+        downpayments.action_post()
+
+        final_invoice = order._create_invoices(final=True)
+
+        # el ajuste no toca estas lineas: sin residuo sub-centavo el objetivo es el importe crudo
+        targets = final_invoice.downpayment_base_targets or {}
+        for line in final_invoice.invoice_line_ids.filtered(
+            lambda line: line.display_type == "product" and not line.is_downpayment
+        ):
+            self.assertAlmostEqual(abs(targets.get(str(line.id), 0.0)), abs(line.price_subtotal), places=2)
+        self.assertGreater(
+            sum(downpayments.mapped("amount_untaxed")),
+            order.amount_untaxed,
+            "el escenario requiere que el wizard haya cobrado de mas",
+        )
+        sign = 1 if final_invoice.move_type == "out_invoice" else -1
+        self.assertAlmostEqual(
+            sum(downpayments.mapped("amount_untaxed")) + sign * final_invoice.amount_untaxed,
+            order.amount_untaxed,
+            places=2,
+            msg="lo facturado tiene que seguir sumando la base de la orden",
+        )
+
+    def test_purchase_bill_is_not_adjusted(self):
+        """El ajuste es solo de ventas.
+
+        purchase tambien setea is_downpayment en account.move.line, y en un documento de compra la
+        clave de grupo no aplica (no hay sale_line_ids, asi que lineas de distintas ordenes de compra
+        caerian en un mismo grupo). Ademas la contabilidad de compras no es asunto de este modulo.
+        """
+        bill = self.env["account.move"].create(
+            {
+                "move_type": "in_invoice",
+                "partner_id": self.partner_a.id,
+                "invoice_date": "2026-01-01",
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product_a_tax.id,
+                            "quantity": 0.5,
+                            "price_unit": 1.01,
+                            "tax_ids": [Command.clear()],
+                        }
+                    )
+                    for dummy in range(3)
+                ]
+                + [
+                    Command.create(
+                        {
+                            "product_id": self.product_a_tax.id,
+                            "quantity": -1.0,
+                            "price_unit": 1.52,
+                            "tax_ids": [Command.clear()],
+                            "is_downpayment": True,
+                        }
+                    )
+                ],
+            }
+        )
+
+        self.assertFalse(bill.downpayment_base_targets, "una factura de compra no tiene que recibir el ajuste")


### PR DESCRIPTION
### What

With "Round Globally" tax rounding, invoicing a down payment and then creating the final invoice can leave the final invoice one cent away from the sales order total. When the down payment covers the order entirely, the final invoice even comes out as a **credit note of 0.01** instead of an invoice of 0.00 — and cancelling that credit note with a debit note duplicates the quantities.

### Why it happens

The down payment wizard rounds the down payment `price_unit` to the currency **once per (taxes, account) combination** (`sale/wizard/sale_make_invoice_advance.py`, `_prepare_down_payment_lines_values`). The product lines it offsets are aggregated from their raw amounts, so when a subtotal falls below the currency precision — a discount such as 15% off 1000.10 => 850.085, or a decimal quantity such as 0.5 at 1.01 => 0.505 — the residual of the whole set is amplified by `round_globally` into a full cent. That cent lands on a base line and can flip the sign of the total.

### Fix

Aggregate and round the product lines of the final invoice with the same partition the down payment used, and feed the result through `manual_total_excluded_currency`. `price_unit`, `price_subtotal` and the raw amounts are untouched; what moves is the line's `total_excluded` — and with it its accounting balance — by the cent that is precisely the bug.

Each down payment line of the invoice already carries the key of its own group, so the partition is **read from those lines** — by order and taxes — rather than derived again. The wizard also groups by account, but the account that ends up on the down payment line cannot be re-derived reliably from the product, so rather than guessing it the code checks separately that the down payment lines of a group share a single one, and leaves the group alone when they do not. A group can hold more than one down payment line — that happens when an order was paid in advance in several rounds — and the target is the same either way: the aggregate of the group rounded once. A group of product lines with no down payment line of its own is left alone, so an unforeseen setup falls back to the standard rounding instead of risking a different discrepancy.

The adjustment is applied **only through `_get_rounded_base_and_tax_lines`**, the path that produces the accounting amounts and the invoice totals. Other consumers of the per-line hook keep seeing the raw base — the early payment discount scales `price_unit` after building the base line, and several EDIs aggregate a subset of the lines, so a pinned group base would give them a wrong amount.

The per-invoice map is memoized in a non-stored computed field, so the hook — which core calls once per line — stays O(n) on the number of invoice lines.

Restricted to `round_globally`, the only rounding method where this residual appears.

### Test plan

`sale_ux/tests/test_downpayment_rounding.py`, all under `round_globally`:

| Scenario | Expected |
|---|---|
| 1 line qty 0.5 @ 1.01, 100% down payment | final invoice of 0.00, not a credit note |
| 3 lines, 100% | final 0.00; down payment + final == order total |
| 5 lines, 100% | idem — the error used to grow with the number of lines |
| 3 lines, 40% | down payment + final == order total |
| 2 different taxes, 100% | two down payment lines, final 0.00 |
| 3 lines without residual, 30% | unchanged (90.00 + 210.00 on 300.00) |
| a down payment account configured on the product category | final 0.00 — the partition must not depend on re-deriving that account |
| residual from a **discount**, down payment charged in **two rounds** | final 0.00, not a credit note; the three documents sum to the order total |
| a fixed tax on some lines only, 50% | invoiced base == order base (the group must not be split) |
| consolidated final invoice deducting one down payment per order | final 0.00, not a credit note |
| `round_per_line` | adjustment stays inactive |

### Scope

Core handles this natively from 18.3 onwards — the tax engine gained dedicated down payment support (`account.tax._prepare_down_payment_lines` / `_prepare_base_lines_for_down_payment`, verified on 19.0) and sets the same `manual_total_excluded_currency` this override sets. So this is meant for **18.0 only and must not be forward-ported to 19.0**, where it would overwrite the value core computes. Suggested merge: `fw=no`.

### Known limitations

- The **down payment itself** can end one cent above the order total, and then the final invoice is negative by that cent. Two ways in: several tax groups (the wizard rounds per group while the order aggregates everything at once), or a down payment charged in several rounds (each round rounds its own amount, so 2 x 50% of 1.01 bills 0.51 + 0.51). Both are the wizard's rounding, happen with or without this change — where there is no sub-cent residual the adjustment is a no-op — and are out of scope here. `test_downpayment_rounded_up_in_several_rounds` pins the behaviour; what holds either way is that the invoiced total still matches the order total.
- Invoices **posted before** this change keep their stored amounts, while the tax totals widget recomputes on every render, so such an invoice can display a total one cent away from what is booked. It only affects invoices that already carry the defect; they need the usual accounting correction, not a recompute.
- `_round_tax_details_base_lines` is mirrored in `account_tax.js`, so while the final invoice is still a draft the browser widget can show a total that differs until it is saved. In practice the final invoice is created by `_create_invoices` rather than typed by hand.
