### PR TITLE
[FIX] sale_order_type_automation: block confirmation on invalid invoice

### DIFF
--- a/sale_order_type_automation/models/account_move.py
+++ b/sale_order_type_automation/models/account_move.py
@@ -2,11 +2,58 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import fields, models
+from odoo import _, fields, models
 
 
 class AccountMove(models.Model):
     _inherit = "account.move"
+
+    def _get_invoicing_automation_blocking_reasons(self):
+        """Return ``{move.id: reason}`` for invoices that must not be posted automatically.
+
+        These are the failures that can be known BEFORE calling ``action_post``. Trying
+        and failing is not harmless: ``_post`` writes ``state`` before the constraints
+        run and nothing rolls that write back, so the next flush persists a move that is
+        'posted' with no number and no document type. Skipping the post leaves a clean
+        draft plus an explanatory log instead, which is the same treatment the invoices
+        excluded by ``invoice_validate_domain`` already get.
+        """
+        reasons = {}
+        # soft dependency: only latam localizations require a document type
+        if "l10n_latam_document_type_id" not in self._fields:
+            return reasons
+        for move in self.filtered(lambda x: x.l10n_latam_use_documents and not x.l10n_latam_document_type_id):
+            reason = _(
+                "The journal '%(journal)s' requires a document type and none could be " "determined for %(partner)s.",
+                journal=move.journal_id.display_name,
+                partner=move.partner_id.display_name,
+            )
+            responsibility_field = "l10n_ar_afip_responsibility_type_id"
+            if responsibility_field in move.partner_id._fields and not move.partner_id[responsibility_field]:
+                reason += _(" Please configure the ARCA Responsibility of the customer.")
+            reasons[move.id] = reason
+        return reasons
+
+    def _recover_failed_automatic_post(self):
+        """Undo the state a failed ``action_post`` left behind on these invoices.
+
+        ``_post`` writes ``state`` through ``write()``, which validates the constraints
+        only after updating the cache, so a constraint error leaves ``state = 'posted'``
+        pending and the next flush (the failure log itself) persists it: a posted move
+        with no number and no document type. Wrapping the post in a savepoint is not an
+        option here, the AR e-invoice code commits and discards it (ingadhoc/sale#1755),
+        so we only put back the moves left in that impossible shape, which by definition
+        never reached numbering nor the CAE.
+        """
+        broken = self.filtered(lambda x: x.state == "posted" and x.name in (False, "/"))
+        if not broken:
+            return
+        try:
+            broken.sudo().write({"state": "draft", "posted_before": False})
+        except Exception as recovery_error:
+            # never mask the original error: writing on a posted move checks the lock dates
+            message = "Could not restore the draft state of this invoice. Error: %s" % recovery_error
+            broken._message_log_batch(bodies=dict.fromkeys(broken.ids, message))
 
     def _prepare_dict_account_payment(self, invoice, payment_journal):
         return {

--- a/sale_order_type_automation/models/sale_order.py
+++ b/sale_order_type_automation/models/sale_order.py
@@ -72,9 +72,40 @@ class SaleOrder(models.Model):
                     invoices_not_validated = rec.env["account.move"]
                 if not invoices_to_validate:
                     continue
+                # Don't even try to post what we already know will fail: a failed action_post
+                # cannot be rolled back (see _recover_failed_automatic_post) and would leave the
+                # invoice marked as posted without number nor document type.
+                blocking_reasons = invoices_to_validate._get_invoicing_automation_blocking_reasons()
+                if blocking_reasons:
+                    reasons = "\n* ".join(blocking_reasons.values())
+                    if not rec.env.context.get("commit_invoice_automation"):
+                        # Block the confirmation, as it was done up to v18: raising rolls the
+                        # request back, so the order is left unconfirmed with nothing dangling.
+                        raise UserError(
+                            _(
+                                "The invoices of the order %(order)s cannot be validated "
+                                "automatically:\n* %(reasons)s",
+                                order=rec.display_name,
+                                reasons=reasons,
+                            )
+                        )
+                    # Batch run: it already committed, so it cannot be torn down. Leave the
+                    # invoices as clean drafts and report why they were not validated.
+                    blocked = invoices_to_validate.browse(blocking_reasons.keys())
+                    blocked._message_log_batch(bodies=blocking_reasons)
+                    rec.message_post(
+                        body=_(
+                            "The following invoices were created but not validated " "automatically:\n* %(reasons)s",
+                            reasons=reasons,
+                        )
+                    )
+                    invoices_to_validate -= blocked
+                    if not invoices_to_validate:
+                        continue
                 try:
                     invoices_to_validate.sudo().action_post()
                 except Exception as error:
+                    invoices_to_validate._recover_failed_automatic_post()
                     message = _(
                         "We couldn't validate the automatically created "
                         "invoices (ids %s), you will need to validate them"

--- a/sale_order_type_automation/tests/test_invoice_automation_error.py
+++ b/sale_order_type_automation/tests/test_invoice_automation_error.py
@@ -2,9 +2,11 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
+import contextlib
 from unittest.mock import patch
 
 from odoo.addons.sale.tests.common import TestSaleCommon
+from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged
 
 
@@ -29,6 +31,26 @@ class TestInvoiceAutomationError(TestSaleCommon):
         sale_exception_installed = cls.env["sale.order"]._fields.get("ignore_exception")
         if sale_exception_installed:
             cls.env["exception.rule"].search([("active", "=", True)]).write({"active": False})
+
+    BLOCKING_REASON = "Falta la Responsabilidad ARCA"
+
+    @contextlib.contextmanager
+    def _blocked_invoices(self):
+        """Fuerza un motivo de bloqueo y falla ruidosamente si igual se intenta registrar."""
+        AccountMove = type(self.env["account.move"])
+        with (
+            patch.object(
+                AccountMove,
+                "_get_invoicing_automation_blocking_reasons",
+                lambda moves: dict.fromkeys(moves.ids, self.BLOCKING_REASON),
+            ),
+            patch.object(
+                AccountMove,
+                "action_post",
+                side_effect=AssertionError("no se debe intentar registrar la factura"),
+            ),
+        ):
+            yield
 
     def _create_so(self):
         product = self.company_data["product_service_order"]
@@ -73,4 +95,71 @@ class TestInvoiceAutomationError(TestSaleCommon):
         self.assertTrue(
             any("ARCA timeout" in (m.body or "") for m in so.message_ids),
             "Se esperaba mensaje de error en el chatter de la orden de venta",
+        )
+
+    def test_blocking_reason_aborts_confirmation(self):
+        """Si ya se sabe que la factura no se puede registrar, la confirmación de la venta
+        se traba (como en la v18) y no se intenta registrar nada."""
+        so = self._create_so()
+        with self._blocked_invoices():
+            with self.assertRaises(UserError) as capture:
+                so.action_confirm()
+
+        self.assertIn(self.BLOCKING_REASON, str(capture.exception))
+        # En uso real el UserError revierte la confirmación por el rollback del request; acá
+        # sólo podemos verificar que ninguna factura llegó a registrarse.
+        self.assertFalse(
+            so.invoice_ids.filtered(lambda x: x.state == "posted"),
+            "No debe haber quedado ninguna factura registrada",
+        )
+
+    def test_blocking_reason_does_not_abort_batch(self):
+        """En el camino batch (ya commiteado) no se puede trabar: la factura queda como
+        borrador limpio con el motivo en el chatter."""
+        so = self._create_so()
+        # el módulo hace cr.commit() en este camino y los tests de Odoo lo prohíben
+        with self._blocked_invoices(), patch.object(self.env.cr, "commit", lambda: None):
+            so.with_context(commit_invoice_automation=True).action_confirm()
+
+        invoice = so.invoice_ids
+        self.assertEqual(len(invoice), 1)
+        self.assertEqual(invoice.state, "draft", "La factura debe quedar en borrador")
+        self.assertTrue(
+            any(self.BLOCKING_REASON in (m.body or "") for m in invoice.message_ids),
+            "Se esperaba el motivo en el chatter de la factura",
+        )
+        self.assertTrue(
+            any(self.BLOCKING_REASON in (m.body or "") for m in so.message_ids),
+            "Se esperaba el motivo en el chatter del pedido de venta",
+        )
+
+    def test_failed_post_does_not_leave_invoice_posted(self):
+        """Reproduce el bug del ticket 125388: action_post escribe state='posted' y recién
+        entonces falla la constraint. Sin revertir, el flush del propio aviso de error
+        persiste una factura registrada sin número ni tipo de documento."""
+        so = self._create_so()
+        AccountMove = self.env["account.move"]
+
+        def _post_then_fail(moves):
+            # mismo orden que account.move._post: primero el write, después la validación.
+            # Sin tipo de documento la localización no puede numerar, así que el name queda
+            # en "/" — es la forma exacta de los registros corruptos que dejó el bug.
+            moves.write({"state": "posted", "posted_before": True, "name": "/"})
+            raise ValidationError("El diario requiere un tipo de documento")
+
+        with patch.object(type(AccountMove), "action_post", _post_then_fail):
+            so.action_confirm()
+
+        invoice = so.invoice_ids
+        self.assertEqual(len(invoice), 1)
+        self.assertEqual(
+            invoice.state,
+            "draft",
+            "La factura no debe quedar registrada cuando falló la validación automática",
+        )
+        self.assertFalse(invoice.posted_before)
+        self.assertIn(invoice.name, (False, "/"), "La factura no debe haber quedado numerada")
+        self.assertTrue(
+            any("tipo de documento" in (m.body or "") for m in so.message_ids),
+            "Se esperaba el aviso del error en el chatter del pedido de venta",
         )


### PR DESCRIPTION
[FIX] sale_order_type_automation: block confirmation on invalid invoice

- Add account.move._get_invoicing_automation_blocking_reasons: reasons why an
  invoice cannot be posted (latam journal requiring a document type with none
  determined, hinting at the customer's missing ARCA responsibility). Soft
  dependency, no-op without the latam localization
- Raise UserError before posting when there is a reason, restoring the 18.0
  behaviour dropped in #1688 and not put back by the #1755 revert. Batch runs
  (commit_invoice_automation) already committed: they skip the post and log
- Add account.move._recover_failed_automatic_post, called from the except: a
  failed _post leaves state='posted' dirty in cache and the failure log itself
  flushes it, persisting an invoice posted with no number nor document type
- Add tests for the three paths, one reproducing the corrupt state

Change note: Al confirmar un pedido de venta con automatización de facturas, si la factura no puede emitirse porque falta un dato — por ejemplo, la Responsabilidad ARCA del contacto — el sistema vuelve a frenar la confirmación indicando qué corregir, como en la versión anterior. Antes el pedido se confirmaba igual y quedaba una factura registrada sin número ni tipo de documento.
