### PR TITLE
[FIX] sale_gathering: keep down payment when balance is recomputed cross-company

### DIFF
--- a/sale_gathering/models/sale_order.py
+++ b/sale_gathering/models/sale_order.py
@@ -42,6 +42,14 @@ class SaleOrder(models.Model):
             )
         )
 
+        # invoice_lines may be cached empty from a read under a restricted
+        # multi-company context, which would zero the down payment
+        downpayment_lines = orders_gathering.order_line.filtered(
+            lambda line: line.is_downpayment and not line.display_type
+        )
+        if downpayment_lines:
+            downpayment_lines.invalidate_recordset(["invoice_lines"])
+
         for order in orders_gathering:
             lines = order._get_gathering_lines()
             total_downpayment_amount = 0
@@ -50,7 +58,7 @@ class SaleOrder(models.Model):
                 and not l.display_type
                 and any(
                     il.parent_state != "cancel"
-                    for il in l.invoice_lines
+                    for il in l.sudo().invoice_lines
                     if len(il.move_id.invoice_line_ids.sale_line_ids.filtered("is_downpayment")) == 1
                 )
             ):


### PR DESCRIPTION
## Problem

`sale.order.gathering_balance` is a **stored** computed field, so its value must
not depend on which companies are enabled by the user that happens to trigger the
recomputation. Today it does.

When the down payment of a gathering order is invoiced from a company other than
the order's own, any earlier read of `invoice_lines` in the same transaction
leaves the relation cached as **empty** — the multi-company record rule on
`account.move.line` filters it out for a user standing on a single company. The
compute later reuses that stale cache entry, so:

- no down payment line passes the "has a non-cancelled invoice line" gate,
- `total_downpayment_amount` evaluates to `0`,
- the stored balance becomes exactly **minus the withdrawn amount** (which reads
  as a large negative number, or as `0` on orders with no withdrawals yet).

`compute_sudo` does not help: by the time the compute runs, the poisoned value is
already in the cache and `sudo()` resolves to the very same entry.

Two visible symptoms, one root cause:

| Does the constraint run? | Outcome |
|---|---|
| The operation writes `is_gathering` / `amount_total` | `ValidationError: the gathering balance will be negative` on a legitimate operation |
| It does not | The wrong balance is **silently stored** and tracked on the order |

The value can also appear to fix itself later: any user standing on both companies
who touches the order recomputes it correctly.

## Fix

Drop the cached `invoice_lines` of the down payment lines before the loop, so the
relation is fetched again from the compute's superuser environment, and read it
through `sudo()` to make the intent explicit.

## Test plan

Reproduced and verified on a restored copy of a production database:

1. Gathering order in company A, down payment invoiced in company B, positive
   stored balance. A user standing on **company A only** validates a delivery.
   - **Before:** the stored balance drops from `5,519,020.70` to `-3,590,268.05`,
     exactly minus the withdrawn amount.
   - **After:** it holds at `5,519,020.70`.
2. Recomputing orders known to be corrupted from a single-company context returns
   their correct balance with the patch, and a wrong one without it.
3. Regression: recomputing 200 gathering orders with and without the patch returns
   identical values — the fix is a no-op under normal conditions.
