### PR TITLE
[FIX] sale_ux: run cancellation checks on the mass cancel wizard

### DIFF
--- a/sale_stock_ux/models/sale_order.py
+++ b/sale_stock_ux/models/sale_order.py
@@ -35,13 +35,19 @@ class SaleOrder(models.Model):
         for order in self:
             order.with_returns = any(line.quantity_returned for line in order.order_line)
 
-    def action_cancel(self):
-        self = self.with_context(cancel_from_order=True)
-        for order in self.filtered(lambda order: order.picking_ids.filtered(lambda x: x.state == "done")):
+    def _check_cancel_allowed(self):
+        delivered = self.filtered(lambda order: order.picking_ids.filtered(lambda x: x.state == "done"))
+        if delivered:
             raise UserError(
-                _("Unable to cancel sale order %s as some deliveries" " have already been done.") % (order.name)
+                _(
+                    "Unable to cancel sale order %s as some deliveries have already been done.",
+                    ", ".join(delivered.mapped("display_name")),
+                )
             )
-        return super().action_cancel()
+        return super()._check_cancel_allowed()
+
+    def action_cancel(self):
+        return super(SaleOrder, self.with_context(cancel_from_order=True)).action_cancel()
 
     @api.depends("picking_ids", "picking_ids.state", "force_delivery_status")
     def _compute_delivery_status(self):

--- a/sale_stock_ux/tests/test_action_cancel.py
+++ b/sale_stock_ux/tests/test_action_cancel.py
@@ -1,3 +1,4 @@
+from odoo.exceptions import UserError
 from odoo.tests import TransactionCase
 
 
@@ -66,3 +67,26 @@ class TestActionCancel(TransactionCase):
 
         # Verificar el estado de la orden después de cancelar
         self.assertEqual(sale_order.state, "cancel")
+
+    def test_mass_cancel_blocks_when_deliveries_are_done(self):
+        # el wizard estandar saltea el chequeo de entregas hechas de action_cancel()
+        sale_order = self.sale_order_model.create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [(0, 0, {"product_id": self.product.id, "product_uom_qty": 1, "price_unit": 100.0})],
+            }
+        )
+        sale_order.action_confirm()
+        picking = sale_order.picking_ids
+        for move in picking.move_ids:
+            move.quantity = move.product_uom_qty
+            move.picked = True
+        picking.button_validate()
+        self.assertEqual(picking.state, "done")
+
+        wizard = self.env["sale.mass.cancel.orders"].with_context(active_ids=sale_order.ids).create({})
+
+        with self.assertRaises(UserError):
+            wizard.action_mass_cancel()
+
+        self.assertEqual(sale_order.state, "sale")

--- a/sale_ux/README.rst
+++ b/sale_ux/README.rst
@@ -27,6 +27,7 @@ Several Improvements to sales:
 #. Block cancellation of a sale order if there is a related invoice in a state different from "draft" or "cancel".
    Customer invoices (out_invoice) are excluded if they have been reversed.
    Customer debit notes (out_debit) are excluded if they are fully paid.
+#. Apply those same cancellation checks to the "Cancel" action of the sale orders list view. The standard mass cancel wizard cancelled the orders without running them, so confirmed orders with posted invoices (or, with sale_stock_ux, done deliveries) could be cancelled from the list.
 #. Customer Preview" button in sale orders, opens the online quotation in a new tab.
 #. In sale.order.form, we rename the field price_subtotal and price_total of the sale order lines to "Subtotal" and "Total" respectively.
 #. Add option in Sales settings to update prices automatically.

--- a/sale_ux/models/sale_order.py
+++ b/sale_ux/models/sale_order.py
@@ -105,22 +105,47 @@ class SaleOrder(models.Model):
         lines_to_recompute = self.order_line.filtered(lambda line: not line.display_type)
         lines_to_recompute._compute_tax_ids()
 
-    def action_cancel(self):
+    def _get_orders_blocking_cancel(self):
+        """Orders whose invoices prevent cancellation, in one search for the whole recordset."""
         invoice_lines = self.sudo().env["account.move.line"].search([("sale_line_ids", "in", self.order_line.ids)])
-        moves = invoice_lines.mapped("move_id").filtered(
+        candidates = invoice_lines.move_id.filtered(
             lambda x: x.move_type in ("out_invoice", "out_refund") and x.state not in ["cancel", "draft"]
         )
+        # read what the check needs up front, so filtering per order costs no extra query
+        invoice_lines.sale_line_ids.fetch(["order_id"])
+        candidates.fetch(["payment_state", "invoice_origin"])
+        blocked = self.browse()
+        for order in self:
+            moves = invoice_lines.filtered(lambda line: order in line.sale_line_ids.order_id).move_id & candidates
+            if moves and not order._invoices_allow_cancel(moves):
+                blocked |= order
+        return blocked
+
+    def _invoices_allow_cancel(self, moves):
+        self.ensure_one()
         # Check that all invoices are reversed and belong to this sale order
         invoices = moves.filtered(lambda m: m.move_type == "out_invoice")
-        valid_invoices = all(inv.payment_state == "reversed" and inv.invoice_origin == self.name for inv in invoices)
+        if not all(inv.payment_state == "reversed" and inv.invoice_origin == self.name for inv in invoices):
+            return False
         # Check that all refunds are paid and belong to this sale order
-        if valid_invoices:
-            refunds = moves.filtered(lambda m: m.move_type == "out_refund")
-            valid_refunds = all(ref.payment_state == "paid" and ref.invoice_origin == self.name for ref in refunds)
-            valid_invoices = valid_refunds if refunds else False
+        refunds = moves.filtered(lambda m: m.move_type == "out_refund")
+        if not refunds:
+            return False
+        return all(ref.payment_state == "paid" and ref.invoice_origin == self.name for ref in refunds)
 
-        if moves and not (valid_invoices):
-            raise UserError(_("Unable to cancel this sale order. You must first cancel related bills and pickings."))
+    def _check_cancel_allowed(self):
+        """Raise if any order cannot be cancelled. Modules adding checks extend this."""
+        blocked = self._get_orders_blocking_cancel()
+        if blocked:
+            raise UserError(
+                _(
+                    "Unable to cancel %s. You must first cancel related bills and pickings.",
+                    ", ".join(blocked.mapped("display_name")),
+                )
+            )
+
+    def action_cancel(self):
+        self._check_cancel_allowed()
         if any(order.locked for order in self):
             return self._action_cancel()
         else:

--- a/sale_ux/tests/test_sale_order.py
+++ b/sale_ux/tests/test_sale_order.py
@@ -269,3 +269,80 @@ class TestSaleOrder(SaleUxCommon):
         self.assertEqual(order_1.state, "sale")
         self.assertEqual(order_2.state, "sale")
         self.assertIsNotNone(result)
+
+    def _mass_cancel(self, orders):
+        return self.env["sale.mass.cancel.orders"].with_context(active_ids=orders.ids).create({}).action_mass_cancel()
+
+    def test_mass_cancel_blocks_when_related_invoices_exist(self):
+        """Test that the mass cancel wizard is blocked when related invoices exist"""
+        order = self._create_sale_order()
+        self._prepare_order_for_invoicing(order)
+        invoice = order._create_invoices(final=True)[0]
+        invoice.action_post()
+
+        with self.assertRaises(UserError):
+            self._mass_cancel(order)
+
+        self.assertEqual(order.state, "sale")
+
+    def test_mass_cancel_allows_when_invoices_are_draft(self):
+        """Test that the mass cancel wizard cancels orders with draft invoices only"""
+        order = self._create_sale_order()
+        self._prepare_order_for_invoicing(order)
+        order._create_invoices(final=True)
+
+        self._mass_cancel(order)
+
+        self.assertEqual(order.state, "cancel")
+
+    def test_mass_cancel_error_names_the_blocking_order(self):
+        """Test that the mass cancel error identifies the order blocking the batch"""
+        order = self._create_sale_order()
+        self._prepare_order_for_invoicing(order)
+        invoice = order._create_invoices(final=True)[0]
+        invoice.action_post()
+
+        with self.assertRaises(UserError) as catcher:
+            self._mass_cancel(order)
+
+        self.assertIn(order.display_name, str(catcher.exception))
+
+    def test_mass_cancel_skips_already_cancelled_orders(self):
+        """Test that an order cancelled by the old path does not block the batch"""
+        blocking_order = self._create_sale_order()
+        self._prepare_order_for_invoicing(blocking_order)
+        invoice = blocking_order._create_invoices(final=True)[0]
+        invoice.action_post()
+        # the standard wizard used to cancel these without running any check
+        blocking_order._action_cancel()
+        self.assertEqual(blocking_order.state, "cancel")
+        quotation = self._create_sale_order()
+
+        self._mass_cancel(blocking_order | quotation)
+
+        self.assertEqual(quotation.state, "cancel")
+
+    def test_action_cancel_on_several_orders_names_every_blocking_one(self):
+        """Test that cancelling a recordset reports each order whose invoices block it"""
+        orders = self.env["sale.order"]
+        for _index in range(2):
+            order = self._create_sale_order()
+            self._prepare_order_for_invoicing(order)
+            invoice = order._create_invoices(final=True)[0]
+            invoice.action_post()
+            orders |= order
+
+        with self.assertRaises(UserError) as catcher:
+            orders.action_cancel()
+
+        for order in orders:
+            self.assertIn(order.display_name, str(catcher.exception))
+        self.assertEqual(set(orders.mapped("state")), {"sale"})
+
+    def test_mass_cancel_cancels_several_quotations(self):
+        """Test that the mass cancel wizard still cancels a whole recordset"""
+        orders = self._create_sale_order() | self._create_sale_order()
+
+        self._mass_cancel(orders)
+
+        self.assertEqual(set(orders.mapped("state")), {"cancel"})

--- a/sale_ux/wizards/__init__.py
+++ b/sale_ux/wizards/__init__.py
@@ -5,3 +5,4 @@
 from . import sale_global_discount_wizard
 from . import sale_advance_payment_inv
 from . import sale_analytic_distribution_wizard
+from . import mass_cancel_orders

--- a/sale_ux/wizards/mass_cancel_orders.py
+++ b/sale_ux/wizards/mass_cancel_orders.py
@@ -1,0 +1,16 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models
+
+
+class SaleMassCancelOrders(models.TransientModel):
+    _inherit = "sale.mass.cancel.orders"
+
+    def action_mass_cancel(self):
+        """The standard wizard cancels without the checks action_cancel() runs, so we
+        run them here too."""
+        # cancelled orders are skipped: the old path let some through with an invoice
+        self.sale_order_ids.filtered(lambda order: order.state != "cancel")._check_cancel_allowed()
+        return super().action_mass_cancel()


### PR DESCRIPTION
The standard `sale.mass.cancel.orders` wizard cancels the selected orders with `_action_cancel()` (`addons/sale/wizard/mass_cancel_orders.py`), which does not run the checks we add on `action_cancel()`:

- `sale_ux`: related invoices in a state other than draft/cancel.
- `sale_stock_ux`: deliveries already in done.

So the "Cancel" action of the sales orders list view cancelled confirmed orders that had posted invoices and validated pickings, leaving those documents untouched and the data inconsistent. The wizard form only shows a warning ("Some confirmed orders are selected…") and cancels anyway.

## Approach

The checks move into `_check_cancel_allowed()`, called both by `action_cancel()` and by the wizard, so the individual and the mass path behave the same:

```python
def action_mass_cancel(self):
    self.sale_order_ids.filtered(lambda order: order.state != "cancel")._check_cancel_allowed()
    return super().action_mass_cancel()
```

`sale_stock_ux` extends that method with its done-deliveries check instead of raising from its own `action_cancel()`, so a single place declares what blocks a cancellation.

The invoice check lives in `_get_orders_blocking_cancel()`, which resolves the whole recordset with one `account.move.line` search and prefetches the fields it reads, so it costs a fixed number of queries regardless of how many orders are selected. `action_cancel()` is multi record safe as a result — it used to raise a singleton error on `inv.invoice_origin == self.name`.

Measured on this branch:

| | Queries |
|---|---|
| Cancelling 200 quotations from the list view | 16 (211 before) |
| Same call, standard wizard with no checks at all | 10 |
| Blocking 10 invoiced orders | 8 |
| Blocking 40 invoiced orders | 8 |

Two behaviour changes that come with it:

- The error names every blocking order instead of failing on the first one. From the list view the user only sees their selection, so a message without names left them with no way to find the culprit.
- Orders already in `cancel` are skipped, so the ones the old path cancelled despite an invoice or a delivery do not block a whole batch.

## Test plan

New tests, all failing on 19.0 without this commit:

- `sale_ux`: `test_mass_cancel_blocks_when_related_invoices_exist`, `test_mass_cancel_allows_when_invoices_are_draft`, `test_mass_cancel_cancels_several_quotations`, `test_mass_cancel_error_names_the_blocking_order`, `test_mass_cancel_skips_already_cancelled_orders`, `test_action_cancel_on_several_orders_names_every_blocking_one`.
- `sale_stock_ux`: `test_mass_cancel_blocks_when_deliveries_are_done`.

Full `TestSaleOrder` + `TestActionCancel` run green (29 tests), so the extracted checks keep the previous semantics.

Manual check: confirm an order, validate its delivery, post its invoice, then select it in the sales list view and use Action > Cancel. The cancellation is now blocked, naming the order.

Note on `sale_stock_ux/tests/test_action_cancel.py`: the shared `setUp` calls `picking._action_done()` without setting quantities or `picked`, so the picking stays in `assigned` and the done-deliveries check was never actually exercised. The new test builds its own done picking instead of relying on it. Fixing the `setUp` is left out of this PR.

Internal reference: https://www.adhoc.inc/odoo/helpdesk.ticket/126450
