### PR TITLE
[ADD] sale_ux: invariants battery for the old quotations cron

### DIFF
--- a/sale_ux/tests/__init__.py
+++ b/sale_ux/tests/__init__.py
@@ -7,6 +7,7 @@ from . import test_account_move
 from . import test_partner_product_config
 from . import test_sale_order
 from . import test_sale_order_line
+from . import test_invariants
 from . import test_settings
 from . import test_wizards
 from . import test_sale_order_unlink

--- a/sale_ux/tests/common.py
+++ b/sale_ux/tests/common.py
@@ -2,8 +2,10 @@ from odoo import Command, fields
 from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
 from odoo.tests.common import TransactionCase
 
+from .invariants import SaleUxInvariants
 
-class SaleUxCommon(TransactionCase):
+
+class SaleUxCommon(SaleUxInvariants, TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/sale_ux/tests/invariants.py
+++ b/sale_ux/tests/invariants.py
@@ -1,0 +1,59 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+
+
+class SaleUxInvariants:
+    """Battery of invariants that must hold after a Sale UX operation.
+
+    Test cases mix this class in through their ``common``, so every suite
+    verifies the same properties over the records the test created itself.
+    The battery has no switches: a scenario that legitimately breaks an
+    invariant declares the exception in the test, not here.
+    """
+
+    def snapshot_states(self, orders):
+        """Capture the state of every order before the operation under test."""
+        return {order.id: order.state for order in orders}
+
+    def assert_cron_cancelled_exactly(self, universe, expected_cancelled, previous_states):
+        """Exactly ``expected_cancelled`` ended up cancelled, and nothing else moved.
+
+        The check runs over ``universe`` only -- the records the test created --
+        so unrelated orders living in the database never relax it.
+
+        :param universe: every sale.order the test created
+        :param expected_cancelled: the subset the scenario expects in ``cancel``
+        :param previous_states: ``{id: state}`` taken before the operation
+        """
+        # The scenario must be internally consistent before anything is asserted
+        self.assertFalse(
+            expected_cancelled - universe,
+            "The scenario expects orders outside the universe it declared: %s"
+            % (expected_cancelled - universe).mapped("name"),
+        )
+        self.assertFalse(
+            set(universe.ids) - set(previous_states),
+            "No state was captured before the operation for: %s"
+            % universe.filtered(lambda order: order.id not in previous_states).mapped("name"),
+        )
+        # Read the states again in case the operation ran through another environment
+        universe.invalidate_recordset(["state"])
+        cancelled = universe.filtered(lambda order: order.state == "cancel")
+        self.assertFalse(
+            cancelled - expected_cancelled,
+            "Cancelled orders the scenario did not expect: %s" % (cancelled - expected_cancelled).mapped("name"),
+        )
+        self.assertFalse(
+            expected_cancelled - cancelled,
+            "Orders the scenario expected cancelled and are not: %s" % (expected_cancelled - cancelled).mapped("name"),
+        )
+        # Everything the scenario left out has to keep the state it already had
+        for order in universe - expected_cancelled:
+            self.assertEqual(
+                order.state,
+                previous_states[order.id],
+                "Collateral damage: %s moved from '%s' to '%s' and the scenario did not ask for it"
+                % (order.name, previous_states[order.id], order.state),
+            )

--- a/sale_ux/tests/test_invariants.py
+++ b/sale_ux/tests/test_invariants.py
@@ -1,0 +1,76 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests import tagged
+
+from .common import SaleUxCommon
+
+
+@tagged("post_install", "-at_install")
+class TestSaleUxInvariants(SaleUxCommon):
+    """The battery is verified in both directions: it must not bother a sane
+    operation, and it must catch the defective one it exists to catch."""
+
+    def test_invariant_accepts_a_sane_cron_run(self):
+        """assert_cron_cancelled_exactly stays quiet when the cron cancels
+        exactly the expired quotations and leaves the recent one alone."""
+        # Enable the cancellation with a 10 day window
+        self.IrConfig.set_param("sale_ux.cancel_old_quotations", "True")
+        self.IrConfig.set_param("sale_ux.days_to_keep_quotations", "10")
+        expired = self._create_old_quotation(days_old=20)
+        recent = self._create_old_quotation(days_old=2)
+        universe = expired | recent
+        # Capture the states before the operation under test
+        previous_states = self.snapshot_states(universe)
+
+        self.env["sale.order"]._cron_clean_old_quotations()
+
+        self.assert_cron_cancelled_exactly(universe, expired, previous_states)
+
+    def test_invariant_catches_an_extra_cancellation(self):
+        """A quotation cancelled beyond what the scenario declared is the
+        collateral damage the battery exists to surface."""
+        expected = self._create_old_quotation(days_old=20)
+        bystander = self._create_old_quotation(days_old=2)
+        universe = expected | bystander
+        previous_states = self.snapshot_states(universe)
+        # The operation overreaches and cancels the bystander too
+        universe._action_cancel()
+
+        with self.assertRaises(AssertionError) as error:
+            self.assert_cron_cancelled_exactly(universe, expected, previous_states)
+
+        self.assertIn(bystander.name, str(error.exception))
+
+    def test_invariant_catches_a_missing_cancellation(self):
+        """A quotation the scenario expected cancelled and survived has to fail
+        the battery, not pass silently."""
+        expected = self._create_old_quotation(days_old=20)
+        also_expected = self._create_old_quotation(days_old=30)
+        universe = expected | also_expected
+        previous_states = self.snapshot_states(universe)
+        # Only one of the two expired quotations gets cancelled
+        expected._action_cancel()
+
+        with self.assertRaises(AssertionError) as error:
+            self.assert_cron_cancelled_exactly(universe, universe, previous_states)
+
+        self.assertIn(also_expected.name, str(error.exception))
+
+    def test_invariant_catches_a_collateral_state_change(self):
+        """The number can be right and the record next to it still be broken:
+        an untouched quotation that changed state must fail the battery."""
+        expected = self._create_old_quotation(days_old=20)
+        bystander = self._create_old_quotation(days_old=2)
+        universe = expected | bystander
+        previous_states = self.snapshot_states(universe)
+        # The cancellation is correct, but the bystander moved anyway
+        expected._action_cancel()
+        bystander.state = "sent"
+
+        with self.assertRaises(AssertionError) as error:
+            self.assert_cron_cancelled_exactly(universe, expected, previous_states)
+
+        self.assertIn("Collateral damage", str(error.exception))
+        self.assertIn(bystander.name, str(error.exception))


### PR DESCRIPTION
Adds tests/invariants.py with SaleUxInvariants, a mixin the suites pull in through SaleUxCommon, plus its own tests in both directions.

assert_cron_cancelled_exactly checks that exactly the expected quotations ended up cancelled and that every other order in the universe kept the state it had before the operation. The check runs over the records the test created itself, so unrelated orders living in the database can never relax it.

The collateral-damage half is the point: a suite that only asserts "the one I expected got cancelled" stays green while the record next to it breaks.

test_invariants.py verifies the battery in both senses -- it stays quiet on a sane cron run, and it catches an extra cancellation, a missing one and a collateral state change.