### PR TITLE
[ADD] sale_stock_ux: behaviour test suites on the stock_ux invariant battery

### DIFF
--- a/sale_stock_ux/tests/__init__.py
+++ b/sale_stock_ux/tests/__init__.py
@@ -1,2 +1,14 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import common
 from . import test_action_cancel
 from . import test_return_exchange_demand
+from . import test_cancel_remaining
+from . import test_returns_invoicing
+from . import test_exchanges
+from . import test_delivery_status
+from . import test_order_line_guards
+from . import test_propagation
+from . import test_stock_info

--- a/sale_stock_ux/tests/common.py
+++ b/sale_stock_ux/tests/common.py
@@ -1,0 +1,146 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+"""Configuración de escenario de las suites de sale_stock_ux.
+
+Hereda dos cosas distintas y a propósito:
+
+- **`SaleUxCommon`** (`sale_ux`): plan de cuentas, partners y producto
+  facturado por lo pedido. Es el entorno de venta, y ya existía.
+- **`StockUxInvariants`** (`stock_ux`): la batería de invariantes de stock,
+  que corre en todas las suites de la cadena.
+
+Encima suma las dos invariantes que leen campos que define *este* módulo, y
+los helpers de escenario. Las tres categorías de datos siguen separadas:
+entorno de la base, configuración del escenario creada acá, y documentos
+siempre creados por cada test.
+"""
+
+from odoo import Command
+from odoo.addons.sale_ux.tests.common import SaleUxCommon
+from odoo.addons.stock_ux.tests.invariants import StockUxInvariants
+from odoo.tests import Form
+
+# Un flujo de venta solo puede generar entregas y, en almacenes multi-paso,
+# las patas internas que las alimentan. Es el conjunto que declara este módulo
+# para la invariante parametrizada que vive en stock_ux.
+SALE_FLOW_CODES = ("outgoing", "internal")
+
+
+class SaleStockUxCommon(StockUxInvariants, SaleUxCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.warehouse = cls.env["stock.warehouse"].search([("company_id", "=", cls.env.company.id)], limit=1)
+        cls.stock_location = cls.warehouse.lot_stock_id
+        # sale_exception, cuando está instalado, bloquea confirmaciones con
+        # reglas que son de la base y no del escenario bajo prueba
+        if cls.env["sale.order"]._fields.get("ignore_exception"):
+            cls.env["exception.rule"].search([("active", "=", True)]).write({"active": False})
+        # Mercadería con seguimiento de inventario: la necesitan los escenarios
+        # que reservan, y con stock cargado para no dejar disponible negativo
+        cls.storable_product = cls.env["product.product"].create(
+            {
+                "name": "Sale Stock UX Storable",
+                "type": "consu",
+                "is_storable": True,
+                "invoice_policy": "order",
+                "list_price": 100.0,
+                "taxes_id": [Command.clear()],
+            }
+        )
+        cls._poner_stock(cls.storable_product, 500.0)
+
+    @classmethod
+    def _poner_stock(cls, product, cantidad, location=None):
+        """Deja stock disponible del producto en la ubicación indicada."""
+        cls.env["stock.quant"]._update_available_quantity(product, location or cls.stock_location, cantidad)
+
+    # -- helpers de escenario ------------------------------------------------
+
+    @classmethod
+    def _crear_orden_confirmada(cls, product=None, qty=10.0, **values):
+        """Crea y confirma una orden de una línea del producto indicado."""
+        order = cls._create_sale_order(
+            order_line=[
+                Command.create(
+                    {
+                        "product_id": (product or cls.storable_product).id,
+                        "product_uom_qty": qty,
+                        "price_unit": 100.0,
+                        "tax_ids": [Command.clear()],
+                    }
+                )
+            ],
+            **values,
+        )
+        order.action_confirm()
+        return order
+
+    def _entregar(self, picking, qty=None):
+        """Valida la entrega, opcionalmente entregando menos que la demanda."""
+        for move in picking.move_ids:
+            move.quantity = move.product_uom_qty if qty is None else qty
+        picking.move_ids.picked = True
+        picking._action_done()
+
+    def _wizard_devolucion(self, picking, qty, to_refund):
+        """Abre el wizard de devolución y setea cantidad y reembolso."""
+        wizard = Form(
+            self.env["stock.return.picking"].with_context(
+                active_id=picking.id, active_ids=picking.ids, active_model="stock.picking"
+            )
+        ).save()
+        wizard.product_return_moves.quantity = qty
+        wizard.product_return_moves.to_refund = to_refund
+        return wizard
+
+    # -- invariantes propias de este módulo ----------------------------------
+
+    def assert_all_qty_delivered_consistent(self, order):
+        """``all_qty_delivered`` es siempre lo entregado más lo devuelto.
+
+        Las dos cifras gobiernan a qué cantidad baja "cancelar remanente" y qué
+        estado de entrega muestra la línea, así que un desfasaje entre ellas es
+        lo que convierte una cantidad entregada correcta en una pedida errónea.
+        """
+        for line in order.order_line:
+            self.assertEqual(
+                line.product_uom_id.compare(line.all_qty_delivered, line.qty_delivered + line.quantity_returned),
+                0,
+                "Línea %s: all_qty_delivered %s != qty_delivered %s + quantity_returned %s"
+                % (line.id, line.all_qty_delivered, line.qty_delivered, line.quantity_returned),
+            )
+
+    def assert_delivery_status_declared(self, order):
+        """El estado de entrega es un valor declarado, y orden y líneas no se contradicen."""
+        estados_orden = dict(self.env["sale.order"]._fields["delivery_status"]._description_selection(self.env))
+        estados_linea = dict(self.env["sale.order.line"]._fields["delivery_status"]._description_selection(self.env))
+        self.assertIn(
+            order.delivery_status, estados_orden, "La orden %s tiene un estado de entrega no declarado" % order.name
+        )
+        for line in order.order_line:
+            self.assertIn(
+                line.delivery_status,
+                estados_linea,
+                "La línea %s tiene un estado de entrega no declarado" % line.id,
+            )
+        if order.delivery_status == "full":
+            pendientes = order.order_line.filtered(lambda line: line.delivery_status == "to deliver")
+            self.assertFalse(
+                pendientes,
+                "La orden %s dice entregada por completo y las líneas %s siguen por entregar"
+                % (order.name, pendientes.ids),
+            )
+
+    def assert_bateria_venta(self, order):
+        """Corre la batería entera contra una orden de venta.
+
+        Se llama después de *cada* operación del escenario, no solo al final:
+        los estados que esto ataja suelen verse un paso y quedar tapados por el
+        siguiente.
+        """
+        self.assert_bateria_documento(order.picking_ids, SALE_FLOW_CODES)
+        self.assert_all_qty_delivered_consistent(order)
+        self.assert_delivery_status_declared(order)

--- a/sale_stock_ux/tests/test_cancel_remaining.py
+++ b/sale_stock_ux/tests/test_cancel_remaining.py
@@ -1,0 +1,98 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests import tagged
+
+from .common import SaleStockUxCommon
+
+
+@tagged("post_install", "-at_install")
+class TestCancelRemaining(SaleStockUxCommon):
+    """Cancelar remanente: la cantidad pedida baja a lo efectivamente movido.
+
+    Cubre los comportamientos 7, 11, 14, 15, 22 y 30 del relevamiento. El 16
+    (recursión en packs detallados, sale_order_line.py:150) queda declarado sin
+    implementar: necesita `product_pack` instalado, que no está en el `depends`
+    de este módulo.
+    """
+
+    def test_cancelar_remanente_baja_la_cantidad_a_lo_entregado(self):
+        """Cadena: confirmar, entregar parcial, cancelar remanente, y volver a subir."""
+        order = self._crear_orden_confirmada(qty=10.0)
+        entrega = order.picking_ids
+        self.assert_bateria_venta(order)
+
+        with self.subTest("entregada una parte, la línea sigue por entregar"):
+            self._entregar(entrega, qty=4.0)
+            self.assertEqual(order.order_line.qty_delivered, 4.0)
+            self.assertEqual(order.order_line.delivery_status, "to deliver")
+            self.assert_bateria_venta(order)
+
+        with self.subTest("cancelar remanente deja la línea en lo efectivamente entregado"):
+            order.order_line.button_cancel_remaining()
+            self.assertEqual(order.order_line.product_uom_qty, 4.0)
+            self.assert_bateria_venta(order)
+
+        with self.subTest("la línea queda entregada por completo"):
+            self.assertEqual(order.order_line.delivery_status, "full")
+
+        with self.subTest("no queda demanda viva pendiente"):
+            vivos = order.order_line.move_ids.filtered(lambda m: m.state not in ("done", "cancel"))
+            self.assertFalse(vivos, "Quedaron moves pendientes tras cancelar el remanente")
+
+        with self.subTest("queda registro en el chatter de la orden"):
+            cuerpos = order.message_ids.mapped("body")
+            self.assertTrue(
+                any("Cancel remaining" in str(cuerpo) for cuerpo in cuerpos),
+                "Cancelar remanente tiene que dejar el movimiento asentado en el chatter",
+            )
+
+        with self.subTest("volver a subir la cantidad genera entrega nueva, no una contraentrega"):
+            order.order_line.product_uom_qty = 9.0
+            self.assert_bateria_venta(order)
+
+    def test_cancelar_remanente_destilda_los_remitos_ya_impresos(self):
+        """Un picking impreso se destilda: si no, Odoo mezcla moves y genera contraentrega."""
+        order = self._crear_orden_confirmada(qty=10.0)
+        self._entregar(order.picking_ids, qty=4.0)
+        pendiente = order.picking_ids.filtered(lambda p: p.state not in ("done", "cancel"))
+        pendiente.printed = True
+
+        order.order_line.button_cancel_remaining()
+
+        self.assertFalse(pendiente.printed, "El picking pendiente tiene que quedar destildado")
+        self.assert_bateria_venta(order)
+
+    def test_cancelar_remanente_respeta_la_orden_bloqueada(self):
+        """Una orden bloqueada se destraba para escribir y vuelve a quedar bloqueada."""
+        order = self._crear_orden_confirmada(qty=10.0)
+        self._entregar(order.picking_ids, qty=4.0)
+        order.locked = True
+
+        order.order_line.button_cancel_remaining()
+
+        self.assertEqual(order.order_line.product_uom_qty, 4.0, "La cantidad tiene que haberse escrito igual")
+        self.assertTrue(order.locked, "La orden tiene que volver a quedar bloqueada")
+        self.assert_bateria_venta(order)
+
+    def test_el_wizard_masivo_toca_solo_las_lineas_por_entregar(self):
+        """El wizard cancela el remanente de las líneas en 'to deliver', y solo esas."""
+        order = self._crear_orden_confirmada(qty=10.0)
+        self._entregar(order.picking_ids)
+        self.assertEqual(order.order_line.delivery_status, "full")
+        cantidad_previa = order.order_line.product_uom_qty
+
+        wizard = (
+            self.env["sale.order.cancel.remaining"]
+            .with_context(active_ids=order.ids, active_model="sale.order")
+            .create({})
+        )
+        wizard.action_confirm()
+
+        self.assertEqual(
+            order.order_line.product_uom_qty,
+            cantidad_previa,
+            "Una línea ya entregada por completo no la tiene que tocar el wizard",
+        )
+        self.assert_bateria_venta(order)

--- a/sale_stock_ux/tests/test_delivery_status.py
+++ b/sale_stock_ux/tests/test_delivery_status.py
@@ -1,0 +1,99 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import Command
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+from .common import SaleStockUxCommon
+
+
+@tagged("post_install", "-at_install")
+class TestDeliveryStatus(SaleStockUxCommon):
+    """Estado de entrega forzado y bloqueo de cancelación.
+
+    Cubre los comportamientos 1, 2, 3, 4 y 5 del relevamiento.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Un usuario interno de ventas, sin permisos de administración: es el
+        # que tiene que rebotar contra el control de force_delivery_status
+        cls.usuario_ventas = (
+            cls.env["res.users"]
+            .with_context(no_reset_password=True)
+            .create(
+                {
+                    "name": "Vendedor Sale Stock UX",
+                    "login": "vendedor@salestockux.test",
+                    "email": "vendedor@salestockux.test",
+                    "company_id": cls.env.company.id,
+                    "company_ids": [Command.set(cls.env.company.ids)],
+                    "group_ids": [Command.set([cls.env.ref("sales_team.group_sale_manager").id])],
+                }
+            )
+        )
+
+    def test_solo_un_administrador_puede_forzar_el_estado_de_entrega(self):
+        """Control positivo en los dos caminos: create y write."""
+        order = self._crear_orden_confirmada(qty=10.0)
+        self.assertFalse(
+            self.usuario_ventas.has_group("base.group_system"),
+            "El escenario necesita un usuario sin permisos de administración",
+        )
+
+        with self.subTest("el usuario sí puede escribir la orden"):
+            # Sin este paso el test pasaría por un AccessError, que en Odoo
+            # también es un UserError: verificaría permisos, no el control
+            order.with_user(self.usuario_ventas).write({"client_order_ref": "REF-OK"})
+            self.assertEqual(order.client_order_ref, "REF-OK")
+
+        with self.subTest("pero no puede forzar el estado de entrega al escribir"):
+            with self.assertRaises(UserError) as capturado:
+                order.with_user(self.usuario_ventas).write({"force_delivery_status": "full"})
+            self.assertIn(
+                "Set Delivered",
+                str(capturado.exception),
+                "Tiene que rebotar por el control del módulo, no por falta de permisos",
+            )
+
+        with self.subTest("tampoco al crear la orden"):
+            with self.assertRaises(UserError) as capturado:
+                self.env["sale.order"].with_user(self.usuario_ventas).create(
+                    {"partner_id": self.partner_a.id, "force_delivery_status": "full"}
+                )
+            self.assertIn("Set Delivered", str(capturado.exception))
+
+    def test_el_estado_forzado_pisa_el_de_la_orden_y_el_de_la_linea(self):
+        """Forzado por un administrador, gana sobre lo que diga el cálculo."""
+        order = self._crear_orden_confirmada(qty=10.0)
+        self.assertTrue(order.picking_ids, "El escenario necesita una entrega viva")
+        self.assertEqual(order.order_line.delivery_status, "to deliver")
+
+        order.force_delivery_status = "full"
+
+        with self.subTest("pisa el estado de la orden"):
+            self.assertEqual(order.delivery_status, "full")
+        with self.subTest("pisa el estado de la línea"):
+            self.assertEqual(order.order_line.delivery_status, "full")
+        self.assert_bateria_venta(order)
+
+    def test_no_se_puede_cancelar_una_orden_con_una_entrega_hecha(self):
+        """Cadena: cancelar sin entregas, con entrega hecha, y el estado resultante."""
+        sin_entregas = self._crear_orden_confirmada(qty=10.0)
+
+        with self.subTest("una orden sin entregas hechas se cancela"):
+            sin_entregas.action_cancel()
+            self.assertEqual(sin_entregas.state, "cancel")
+
+        with self.subTest("cancelada, el estado de entrega vuelve a 'nada por entregar'"):
+            self.assertEqual(sin_entregas.delivery_status, "no")
+
+        with self.subTest("una orden con una entrega hecha no se puede cancelar"):
+            entregada = self._crear_orden_confirmada(qty=10.0)
+            self._entregar(entregada.picking_ids)
+            with self.assertRaises(UserError):
+                entregada.action_cancel()
+            self.assertEqual(entregada.state, "sale", "La orden tiene que seguir viva")

--- a/sale_stock_ux/tests/test_exchanges.py
+++ b/sale_stock_ux/tests/test_exchanges.py
@@ -1,0 +1,68 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+from .common import SaleStockUxCommon
+
+
+@tagged("post_install", "-at_install")
+class TestExchanges(SaleStockUxCommon):
+    """Devoluciones para cambio.
+
+    Cubre los comportamientos 19, 23, 27, 28 y 29 del relevamiento.
+    """
+
+    def test_el_wizard_de_devolucion_nace_con_reembolso_tildado(self):
+        """El módulo fuerza to_refund=True por defecto en todas las líneas."""
+        order = self._crear_orden_confirmada(qty=10.0)
+        self._entregar(order.picking_ids)
+
+        wizard = self._wizard_devolucion(order.picking_ids, qty=3.0, to_refund=True)
+
+        self.assertTrue(
+            all(wizard.product_return_moves.mapped("to_refund")),
+            "El default del módulo es devolver con reembolso",
+        )
+
+    def test_no_se_puede_cambiar_una_linea_marcada_para_reembolso(self):
+        """Control positivo: si el sistema tiene que bloquear, hay que ver que bloquee."""
+        order = self._crear_orden_confirmada(qty=10.0)
+        self._entregar(order.picking_ids)
+        wizard = self._wizard_devolucion(order.picking_ids, qty=3.0, to_refund=True)
+
+        with self.assertRaises(UserError):
+            wizard.action_create_exchanges()
+
+    def test_el_cambio_marca_sus_movimientos_y_no_los_mezcla(self):
+        """Cadena: crear el cambio, verificar la marca, validarlo y ver el neto."""
+        order = self._crear_orden_confirmada(qty=10.0)
+        entrega = order.picking_ids
+        self._entregar(entrega)
+        entregado_antes = order.order_line.qty_delivered
+
+        wizard = self._wizard_devolucion(entrega, qty=3.0, to_refund=False)
+        wizard.action_create_exchanges()
+
+        with self.subTest("los movimientos del cambio quedan marcados como tales"):
+            moves_cambio = order.order_line.move_ids.filtered(lambda m: m.is_exchange_move)
+            self.assertTrue(moves_cambio, "Tendrían que existir movimientos marcados como cambio")
+
+        with self.subTest("un movimiento de cambio no se mezcla con uno normal"):
+            self.assertIn(
+                "is_exchange_move",
+                self.env["stock.move"]._prepare_merge_moves_distinct_fields(),
+                "is_exchange_move tiene que ser parte de la clave de merge",
+            )
+
+        with self.subTest("la cantidad entregada neta no se mueve por el cambio"):
+            self.assertEqual(
+                order.order_line.qty_delivered,
+                entregado_antes,
+                "Un cambio saca y repone: la entregada neta no cambia",
+            )
+
+        with self.subTest("el cambio no genera una contraentrega"):
+            self.assert_bateria_venta(order)

--- a/sale_stock_ux/tests/test_order_line_guards.py
+++ b/sale_stock_ux/tests/test_order_line_guards.py
@@ -1,0 +1,42 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests import Form, tagged
+from odoo.tools import mute_logger
+
+from .common import SaleStockUxCommon
+
+
+@tagged("post_install", "-at_install")
+class TestOrderLineGuards(SaleStockUxCommon):
+    """Bloqueo de reducción de cantidad en una orden confirmada.
+
+    Cubre el comportamiento 17 del relevamiento. Es un control positivo: lo
+    que hay que verificar no es que avise, sino que la cantidad **no** cambie.
+    """
+
+    @mute_logger("odoo.tests.form.onchange")
+    def test_no_se_puede_reducir_la_cantidad_de_una_orden_confirmada(self):
+        order = self._crear_orden_confirmada(qty=10.0)
+
+        with Form(order) as form:
+            with form.order_line.edit(0) as linea:
+                linea.product_uom_qty = 4.0
+
+        self.assertEqual(
+            order.order_line.product_uom_qty,
+            10.0,
+            "Reducir la cantidad tiene que revertirse: para bajarla va cancelar remanente",
+        )
+
+    def test_subir_la_cantidad_sigue_permitido(self):
+        """Espejo: el bloqueo es solo hacia abajo."""
+        order = self._crear_orden_confirmada(qty=10.0)
+
+        with Form(order) as form:
+            with form.order_line.edit(0) as linea:
+                linea.product_uom_qty = 15.0
+
+        self.assertEqual(order.order_line.product_uom_qty, 15.0)
+        self.assert_bateria_venta(order)

--- a/sale_stock_ux/tests/test_propagation.py
+++ b/sale_stock_ux/tests/test_propagation.py
@@ -1,0 +1,50 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests import tagged
+
+from .common import SaleStockUxCommon
+
+
+@tagged("post_install", "-at_install")
+class TestPropagation(SaleStockUxCommon):
+    """Propagación de notas al remito y parámetro de unidad de medida.
+
+    Cubre los comportamientos 26 y 31 del relevamiento. Los dos son
+    configuración que gobierna un efecto, así que van juntos y parametrizados.
+    """
+
+    def _set_param(self, clave, valor):
+        self.env["ir.config_parameter"].sudo().set_param(clave, valor)
+
+    def test_las_notas_de_la_orden_viajan_al_remito_segun_el_parametro(self):
+        for clave, campo_orden, campo_picking, texto in [
+            ("sale.propagate_internal_notes", "internal_notes", "note", "Entregar por la puerta lateral"),
+            ("sale.propagate_note", "note", "observations", "Condiciones acordadas con el cliente"),
+        ]:
+            with self.subTest("con el parámetro apagado la nota no viaja", clave=clave):
+                self._set_param(clave, "False")
+                order = self._crear_orden_confirmada(qty=5.0, **{campo_orden: f"<p>{texto}</p>"})
+                self.assertNotIn(texto, str(order.picking_ids[campo_picking] or ""))
+
+            with self.subTest("con el parámetro encendido la nota viaja al remito", clave=clave):
+                self._set_param(clave, "True")
+                order = self._crear_orden_confirmada(qty=5.0, **{campo_orden: f"<p>{texto}</p>"})
+                self.assertIn(texto, str(order.picking_ids[campo_picking] or ""))
+                self.assert_bateria_venta(order)
+
+    def test_el_parametro_de_unidad_de_medida_va_y_vuelve(self):
+        """Round-trip de propagate_uom contra ir.config_parameter."""
+        Config = self.env["res.config.settings"]
+        get_param = self.env["ir.config_parameter"].sudo().get_param
+
+        with self.subTest("encendido guarda 1 y se relee encendido"):
+            Config.create({"propagate_uom": True}).set_values()
+            self.assertEqual(get_param("stock.propagate_uom"), "1")
+            self.assertTrue(Config.new({}).get_values()["propagate_uom"])
+
+        with self.subTest("apagado guarda 0 y se relee apagado"):
+            Config.create({"propagate_uom": False}).set_values()
+            self.assertEqual(get_param("stock.propagate_uom"), "0")
+            self.assertFalse(Config.new({}).get_values()["propagate_uom"])

--- a/sale_stock_ux/tests/test_returns_invoicing.py
+++ b/sale_stock_ux/tests/test_returns_invoicing.py
@@ -1,0 +1,65 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests import tagged
+
+from .common import SaleStockUxCommon
+
+
+@tagged("post_install", "-at_install")
+class TestReturnsInvoicing(SaleStockUxCommon):
+    """Devolución con reembolso y su efecto sobre la facturación.
+
+    Cubre los comportamientos 6, 8, 10, 11, 12 y 13 del relevamiento. Es el
+    mecanismo del que salió la reapertura del ticket 123997: con política por
+    lo pedido, lo devuelto tiene que descontarse de lo facturable o la orden
+    queda "por facturar" para siempre.
+    """
+
+    def test_devolucion_con_reembolso_descuenta_lo_facturable(self):
+        """Cadena: entregar todo, devolver con reembolso, facturar el resto."""
+        order = self._crear_orden_confirmada(qty=10.0)
+        self.assertEqual(order.order_line.product_id.invoice_policy, "order")
+        self._entregar(order.picking_ids)
+        self.assert_bateria_venta(order)
+
+        with self.subTest("entregada la orden, hay 10 por facturar"):
+            self.assertEqual(order.order_line.qty_to_invoice, 10.0)
+
+        with self.subTest("la devolución con reembolso suma a la cantidad devuelta"):
+            wizard = self._wizard_devolucion(order.picking_ids, qty=3.0, to_refund=True)
+            devolucion = self.env["stock.picking"].browse(wizard.action_create_returns()["res_id"])
+            self._entregar(devolucion)
+            self.assertEqual(order.order_line.quantity_returned, 3.0)
+            self.assert_bateria_venta(order)
+
+        with self.subTest("la orden queda marcada como que tiene devoluciones"):
+            self.assertTrue(order.with_returns)
+
+        with self.subTest("con política por lo pedido, lo devuelto sale de lo facturable"):
+            self.assertEqual(
+                order.order_line.qty_to_invoice,
+                7.0,
+                "Tienen que quedar 10 - 3 devueltas por facturar",
+            )
+
+        with self.subTest("facturado el resto, la orden no queda 'por facturar'"):
+            factura = order._create_invoices()
+            factura.action_post()
+            self.assertEqual(order.order_line.qty_invoiced, 7.0)
+            self.assertEqual(order.order_line.invoice_status, "invoiced")
+            self.assert_bateria_venta(order)
+
+    def test_la_devolucion_sin_reembolso_no_toca_lo_facturable(self):
+        """Espejo del anterior: sin reembolso, lo devuelto no descuenta."""
+        order = self._crear_orden_confirmada(qty=10.0)
+        self._entregar(order.picking_ids)
+
+        wizard = self._wizard_devolucion(order.picking_ids, qty=3.0, to_refund=False)
+        devolucion = self.env["stock.picking"].browse(wizard.action_create_returns()["res_id"])
+        self._entregar(devolucion)
+
+        self.assertEqual(order.order_line.quantity_returned, 0.0, "Sin reembolso no cuenta como devuelta")
+        self.assertEqual(order.order_line.qty_to_invoice, 10.0)
+        self.assert_bateria_venta(order)

--- a/sale_stock_ux/tests/test_stock_info.py
+++ b/sale_stock_ux/tests/test_stock_info.py
@@ -1,0 +1,99 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import Command
+from odoo.tests import tagged
+
+from .common import SaleStockUxCommon
+
+
+@tagged("post_install", "-at_install")
+class TestStockInfo(SaleStockUxCommon):
+    """Información de stock que el módulo muestra en la línea de venta.
+
+    Cubre los comportamientos 20 y 21 del relevamiento. Lo que el test va a
+    buscar es la conversión de unidad: una línea en docenas sobre un producto
+    que se lleva en unidades.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Sub-ubicación marcada para mostrar stock: la configuración del
+        # escenario la crea el test, no se hereda de la base
+        cls.estanteria = cls.env["stock.location"].create(
+            {
+                "name": "Estantería Sale Stock UX",
+                "location_id": cls.stock_location.id,
+                "usage": "internal",
+                "show_stock_on_products": True,
+            }
+        )
+        cls.producto_en_unidades = cls.env["product.product"].create(
+            {
+                "name": "Sale Stock UX Por Unidad",
+                "type": "consu",
+                "is_storable": True,
+                "uom_id": cls.product_uom_unit.id,
+                "list_price": 10.0,
+                "taxes_id": [Command.clear()],
+            }
+        )
+        cls._poner_stock(cls.producto_en_unidades, 24.0, location=cls.estanteria)
+
+    def _linea_en_docenas(self, qty=1.0):
+        order = self._create_sale_order(
+            order_line=[
+                Command.create(
+                    {
+                        "product_id": self.producto_en_unidades.id,
+                        "product_uom_qty": qty,
+                        "product_uom_id": self.product_uom_pack.id,
+                        "price_unit": 120.0,
+                        "tax_ids": [Command.clear()],
+                    }
+                )
+            ]
+        )
+        return order
+
+    def test_el_stock_por_ubicacion_se_expresa_en_la_unidad_de_la_linea(self):
+        """24 unidades en la estantería son 2 docenas para una línea en docenas."""
+        order = self._linea_en_docenas()
+
+        texto = order.order_line.stock_by_location or ""
+
+        self.assertIn(self.estanteria.display_name, texto, "Tiene que listar la ubicación marcada")
+        self.assertIn("2.00", texto, "24 unidades son 2 docenas: sin conversión diría 24.00")
+
+    def test_las_ubicaciones_no_marcadas_no_se_listan(self):
+        """Solo salen las ubicaciones con la marca encendida."""
+        sin_marcar = self.env["stock.location"].create(
+            {
+                "name": "Depósito oculto Sale Stock UX",
+                "location_id": self.stock_location.id,
+                "usage": "internal",
+                "show_stock_on_products": False,
+            }
+        )
+        self._poner_stock(self.producto_en_unidades, 60.0, location=sin_marcar)
+        order = self._linea_en_docenas()
+
+        self.assertNotIn(sin_marcar.display_name, order.order_line.stock_by_location or "")
+
+    def test_lo_reservado_sale_del_almacen_de_la_orden_incluyendo_sub_ubicaciones(self):
+        """La reserva vive en una sub-ubicación y tiene que contarse igual."""
+        order = self._linea_en_docenas(qty=1.0)
+        order.action_confirm()
+        order.picking_ids.action_assign()
+        reservado = self.env["stock.quant"].search(
+            [
+                ("product_id", "=", self.producto_en_unidades.id),
+                ("location_id", "child_of", self.warehouse.lot_stock_id.id),
+            ]
+        )
+        total_reservado = sum(reservado.mapped("reserved_quantity"))
+        self.assertGreater(total_reservado, 0.0, "El escenario necesita una reserva viva")
+
+        self.assertEqual(order.order_line.total_reserved_quantity, total_reservado)


### PR DESCRIPTION
## Qué hace

Cubre los comportamientos de negocio de `sale_stock_ux` con siete suites, una por mecanismo, apoyadas en la batería de invariantes que aporta `stock_ux`. **No cambia comportamiento de producto.**

## Depende de ingadhoc/stock#1012

La batería vive en `stock_ux`. **La rama se llama igual en los dos repos a propósito** (`19.0-t-72661-jc-tests`): sin eso runbot arma dos builds independientes y el que tiene estos tests no compila el módulo — falla el import de la batería, no un test.

## Qué agrega `tests/common.py`

Hereda dos cosas distintas: las fixtures de venta de `sale_ux` (plan de cuentas, partners, producto facturado por lo pedido) y la batería de invariantes de `stock_ux`. Encima suma las dos invariantes que leen campos que define **este** módulo:

| Invariante | Qué verifica |
|---|---|
| `assert_all_qty_delivered_consistent` | `all_qty_delivered` es siempre lo entregado más lo devuelto. Las dos cifras gobiernan a qué cantidad baja "cancelar remanente" y qué estado muestra la línea |
| `assert_delivery_status_declared` | El estado de entrega es un valor declarado, y orden y líneas no se contradicen |

`assert_bateria_venta` corre la batería entera contra una orden y **se llama después de cada paso del escenario, no solo al final**: los estados que esto ataja suelen verse un paso y quedar tapados por el siguiente. El flujo de venta declara `("outgoing", "internal")` para la invariante de contraflujo parametrizada.

## Suites

| Archivo | Mecanismo |
|---|---|
| `test_cancel_remaining` | La cantidad pedida baja a lo efectivamente movido; se destildan los remitos impresos; la orden bloqueada se escribe y vuelve a bloquearse; el wizard masivo toca solo las líneas por entregar |
| `test_returns_invoicing` | Una devolución con reembolso deja la orden facturable por el resto en vez de trabada en "por facturar", con la devolución sin reembolso como espejo |
| `test_exchanges` | El wizard nace con reembolso; se rechaza el cambio sobre líneas a reembolsar; los movimientos de cambio se marcan y no se mezclan con los normales; la entregada neta no se mueve |
| `test_delivery_status` | Solo un usuario de administración puede forzar el estado de entrega, en create y en write; una orden con entrega hecha no se cancela |
| `test_order_line_guards` | Reducir la cantidad en una orden confirmada se revierte; subirla sigue permitido |
| `test_propagation` | Las notas de la orden llegan al remito según sus parámetros; el parámetro de unidad va y vuelve |
| `test_stock_info` | El stock por ubicación se expresa en la unidad de la línea; las ubicaciones sin marcar no se listan; lo reservado cuenta sub-ubicaciones |

## Test plan

```
odoo -d <base> -u sale_stock_ux --test-tags /sale_stock_ux --stop-after-init
EXIT=0
odoo.tests.stats:  sale_stock_ux: 41 tests 6.42s 7889 queries
odoo.tests.result: 0 failed, 0 error(s) of 23 tests
```

Sin warnings. El bloqueo de reducción de cantidad emite un warning de `odoo.tests.form.onchange` en su camino esperado, así que el test lleva `@mute_logger` del logger específico — el código productivo no se toca.

### Demostrado en rojo

Verde no alcanza: un test que pasa y un test que no mira nada se ven igual. Por cada comportamiento se removió quirúrgicamente la guarda que protege y se verificó que caiga su test, y solo el suyo. 11 roturas, una por corrida:

| Rotura | Test que cae |
|---|---|
| Cancelar remanente no baja la cantidad | 3 subTests de `test_cancelar_remanente_baja_la_cantidad_a_lo_entregado` |
| No se destildan los remitos impresos | `test_cancelar_remanente_destilda_los_remitos_ya_impresos` |
| La orden bloqueada no se vuelve a bloquear | `test_cancelar_remanente_respeta_la_orden_bloqueada` |
| Lo devuelto no se descuenta de lo facturable | subTest de `test_devolucion_con_reembolso_descuenta_lo_facturable` |
| Reducir la cantidad ya no se revierte | `test_no_se_puede_reducir_la_cantidad_de_una_orden_confirmada` |
| Desaparece la conversión de unidad | `test_el_stock_por_ubicacion_se_expresa_en_la_unidad_de_la_linea` |
| Cancelar con entrega hecha ya no bloquea | subTest de `test_no_se_puede_cancelar_una_orden_con_una_entrega_hecha` |
| El control de permisos sale del `write` | subTest `[pero no puede forzar el estado de entrega al escribir]` |
| El control de permisos sale del `create` | subTest `[tampoco al crear la orden]` |
| Crear cambios ya no rechaza el reembolso | `test_no_se_puede_cambiar_una_linea_marcada_para_reembolso` |
| `is_exchange_move` sale de la clave de merge | subTest de `test_el_cambio_marca_sus_movimientos_y_no_los_mezcla` |
| Las notas dejan de propagarse | subTest de `test_las_notas_de_la_orden_viajan_al_remito` |

El ejercicio encontró un falso positivo antes de que llegara al PR: el test de permisos pasaba con el control borrado, porque el usuario de prueba no tenía permiso de escritura sobre la orden y `AccessError` hereda de `UserError`. Se endureció — el usuario ahora puede escribir la orden (se prueba explícitamente) y el assert exige el mensaje del control del módulo.

## Escenarios declarados, sin implementar

| Escenario | Motivo |
|---|---|
| Cancelar remanente recursa en packs detallados (`sale_order_line.py:150`) | Necesita `product_pack`, que no está en `depends` |
| `quantity_returned` con kits (BoM phantom) | El código tiene un `FIXME` sobre la política correcta en dropship: testearlo hoy fijaría como esperado un comportamiento que está en discusión |
| La rama de suscripciones de `_create_procurements` | Necesita `sale_subscription` |
| `secondary_uom_qty` se recalcula al nacer el move | Necesita `secondary_unit` |

## Tests existentes que conviene revisar (no se tocaron)

- `test_action_cancel.py::test_action_cancel_context` recorre el mismo camino que el test de al lado y assertea comportamiento de core: el contexto que pasa lo inyecta `action_cancel` por su cuenta.
- El `setUp` de ese archivo arma una orden con entrega en `done` que ningún test usa — justo el escenario que `test_delivery_status` cubre ahora.

## Hallazgo de código, va en PR aparte

En Odoo 19 el registro de `decimal.precision` se llama `Product Unit`; `"Product Unit of Measure"` no existe y `precision_get` devuelve 2 en silencio. Hay usos del nombre viejo en `sale_stock_ux/models/sale_order_line.py` (18, 25, 119, 319) y en `sale_ux/models/sale_order.py:161`. No rompe: diverge si el cliente configura más de 2 decimales.

Task: https://www.adhoc.inc/odoo/project.task/72661
