### PR TITLE
[FIX] sale_payment_options: drop invalid t-index directive

### DIFF
--- a/sale_payment_options/report/sale_order_payment_options_report.xml
+++ b/sale_payment_options/report/sale_order_payment_options_report.xml
@@ -37,7 +37,7 @@
                             <tbody>
                                 <t t-set="subtotal" t-value="0"/>
                                 <t t-set="rowspan" t-value="len(opt.options_json) if opt.options_json else 1"/>
-                                <t t-foreach="opt.options_json" t-as="item" t-index="item_index">
+                                <t t-foreach="opt.options_json" t-as="item">
                                     <tr>
                                         <td class="text-start" t-if="item_index == 0" t-att-rowspan="rowspan"><t t-esc="op_index"/></td>
                                         <td class="text-start" t-if="item_index != 0" style="display:none"></td> <!-- The following hidden cell is used to keep table alignment when using rowspan for the index column. -->


### PR DESCRIPTION
`t-index` is an OWL-only directive, ignored by the server-side QWeb engine, which logs `Unknown directives or unused attributes: {'t-index'}` on every render of `sale.report_saleorder_document`. It is also redundant: `t-foreach="..." t-as="item"` already exposes `item_index`, which is what the rowspan cells below already read.

- Remove `t-index="item_index"` from the `options_json` loop
- No rendering change: `item_index` keeps resolving from `t-as`

Change note: Se elimina un atributo inválido en el reporte de opciones de pago que ensuciaba el log con advertencias cada vez que se generaba el PDF de un pedido de venta. El reporte se imprime exactamente igual que antes.