### PR TITLE
[IMP] sale_require_purchase_order_number: send PO number to Chilean DTE

### DIFF
--- a/sale_require_purchase_order_number/README.rst
+++ b/sale_require_purchase_order_number/README.rst
@@ -20,6 +20,24 @@ This module incorporates the following features:
 * Validate that the field is in these documents if the partner has the field "required number of PO".
 * Purchase order number must be unique per partner
 
+Regional scope
+==============
+
+This module only stores and validates the field. Printing it on a document, or
+sending it to a tax authority, is done by each localization, so what you get out
+of the box depends on the country:
+
+* **Argentina** (``l10n_ar_ux``, ``l10n_ar_stock_ux``): printed as "PO Number" on
+  the invoice and on the delivery slip PDF.
+* **Uruguay** (``l10n_uy_ux``): sent to DGI in the ``CompraID`` tag of the CFE,
+  replacing the value taken from ``ref``.
+* **Chile** (``l10n_cl_edi``, ``l10n_cl_edi_stock``): sent to SII as an ODC cross
+  reference of the invoice and of the delivery guide, and printed on both PDFs in
+  the references table. Without this module that cross reference is built from
+  "Your Reference" (``client_order_ref``) instead.
+* **Any other country**: the field is only stored on the record, it is not printed
+  on any document.
+
 Installation
 ============
 

--- a/sale_require_purchase_order_number/__manifest__.py
+++ b/sale_require_purchase_order_number/__manifest__.py
@@ -22,7 +22,9 @@
     "version": "19.0.1.0.0",
     "category": "Sales",
     "sequence": 14,
-    "summary": "",
+    "summary": "Track and require the customer purchase order number. Printing it on a "
+    "document or reporting it to a tax authority is done by each localization: "
+    "Argentina, Uruguay and Chile are covered, other countries only store the field.",
     "author": "ADHOC SA",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",

--- a/sale_require_purchase_order_number/models/account_move.py
+++ b/sale_require_purchase_order_number/models/account_move.py
@@ -2,7 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import _, api, fields, models
+from odoo import Command, _, api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -21,3 +21,37 @@ class AccountInvoice(models.Model):
         )
         if invoices_missing_po_number:
             raise UserError(_("You cannot confirm invoice without a" " Purchase Order Number for this partner"))
+
+    def _set_l10n_cl_purchase_order_reference(self):
+        """In Chile the customer purchase order reaches the DTE and the invoice PDF as an
+        ODC cross reference. l10n_cl_edi only fills those references by hand or from an
+        incoming DTE, so we add ours when the invoice carries a purchase order number.
+        """
+        if "l10n_cl_reference_ids" not in self._fields:
+            return
+        purchase_order_doc_type = self.env.ref("l10n_cl.dc_odc", raise_if_not_found=False)
+        if not purchase_order_doc_type:
+            return
+        for move in self:
+            company = move.company_id
+            if (
+                not move.purchase_order_number
+                or company.account_fiscal_country_id.code != "CL"
+                or not company.l10n_cl_dte_service_provider
+            ):
+                continue
+            # do not add a second one over what the user (or an incoming DTE) already set
+            if move.l10n_cl_reference_ids.filtered(
+                lambda ref: ref.l10n_cl_reference_doc_type_id == purchase_order_doc_type
+            ):
+                continue
+            move.l10n_cl_reference_ids = [
+                Command.create(
+                    {
+                        "origin_doc_number": move.purchase_order_number,
+                        "l10n_cl_reference_doc_type_id": purchase_order_doc_type.id,
+                        "reason": _("Cross Reference To Purchase Order"),
+                        "date": move.invoice_date or fields.Date.context_today(move),
+                    }
+                )
+            ]

--- a/sale_require_purchase_order_number/models/sale_order.py
+++ b/sale_require_purchase_order_number/models/sale_order.py
@@ -27,7 +27,9 @@ class SaleOrder(models.Model):
         )
         if sale_order_missing_po_number:
             raise UserError(_("You cannot confirm a sales order without a Purchase Order Number for this partner"))
-        return super().action_confirm()
+        res = super().action_confirm()
+        self.picking_ids._set_l10n_cl_purchase_order_reference()
+        return res
 
     def _create_invoices(self, grouped=False, final=False, date=None):
         moves = super()._create_invoices(grouped, final, date)
@@ -38,4 +40,5 @@ class SaleOrder(models.Model):
             origins = move.invoice_origin.split(", ")
             po_numbers = [origin_map.get(o) for o in origins if origin_map.get(o)]
             move.purchase_order_number = ", ".join(po_numbers)
+        moves._set_l10n_cl_purchase_order_reference()
         return moves

--- a/sale_require_purchase_order_number/models/stock_picking.py
+++ b/sale_require_purchase_order_number/models/stock_picking.py
@@ -2,7 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import _, api, fields, models
+from odoo import Command, _, api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -33,6 +33,54 @@ class StockPicking(models.Model):
     def _inverse_purchase_order_number(self):
         for rec in self:
             rec.manual_purchase_order_number = rec.purchase_order_number
+
+    def _set_l10n_cl_purchase_order_reference(self):
+        """In Chile the customer purchase order travels on the delivery guide as an ODC
+        cross reference, that l10n_cl_edi_stock builds from client_order_ref. Where this
+        module is installed the purchase order number is the field the user fills, so it
+        is the one that has to reach the DTE.
+
+        Called from sale.order.action_confirm and not from `_get_new_picking_values`
+        because l10n_cl_edi_stock sits above this module in the MRO (it depends on
+        l10n_cl_edi, we only depend on sale_stock) and would overwrite what we set
+        there. `create` is too early as well: sale_id is not resolved yet.
+        """
+        if "l10n_cl_reference_ids" not in self._fields:
+            return
+        purchase_order_doc_type = self.env.ref("l10n_cl.dc_odc", raise_if_not_found=False)
+        if not purchase_order_doc_type:
+            return
+        for picking in self:
+            company = picking.company_id
+            if (
+                not picking.purchase_order_number
+                or picking.backorder_id
+                or company.account_fiscal_country_id.code != "CL"
+                or not company.l10n_cl_dte_service_provider
+            ):
+                # on a backorder l10n_cl_edi_stock copies the references over, to keep an
+                # edit the user made on the original picking
+                continue
+            references = picking.l10n_cl_reference_ids.filtered(
+                lambda ref: ref.l10n_cl_reference_doc_type_id == purchase_order_doc_type
+            )
+            if not references:
+                # client_order_ref was empty, so l10n_cl_edi_stock built no reference
+                picking.l10n_cl_reference_ids = [
+                    Command.create(
+                        {
+                            "origin_doc_number": picking.purchase_order_number,
+                            "l10n_cl_reference_doc_type_id": purchase_order_doc_type.id,
+                            "reason": _("Cross Reference To Purchase Order"),
+                            "date": picking.sale_id.date_order or fields.Date.context_today(picking),
+                        }
+                    )
+                ]
+                continue
+            # only the one built from the sale order, never a value the user typed
+            references.filtered(
+                lambda ref: ref.origin_doc_number == picking.sale_id.client_order_ref
+            ).origin_doc_number = picking.purchase_order_number
 
     def _action_done(self):
         picking_missing_po_number = self.filtered(


### PR DESCRIPTION
Task: https://www.adhoc.inc/odoo/project.task/70070

## Context

This module stores and validates the customer purchase order number, but it does not
print it or report it anywhere: that is done by each localization. Today only two do it:

| Document | Module |
|---|---|
| AR invoice and delivery slip PDF | `l10n_ar_ux`, `l10n_ar_stock_ux` |
| UY CFE (`CompraID` tag) | `l10n_uy_ux` |
| **CL** | **nothing** |

In Chile the customer PO travels as an ODC cross reference (`l10n_cl.edi.reference`,
doc type `l10n_cl.dc_odc`), which reaches both the DTE and the references table of the
PDF. Two gaps:

1. `l10n_cl_edi_stock` builds the delivery guide reference from `client_order_ref`, and
   returns early when that field is empty — so filling only `purchase_order_number`
   produced no reference at all and the PO never reached SII.
2. On invoices, `l10n_cl_edi` fills references only by hand or from an incoming DTE, so
   nothing was created when invoicing a sale order.

## Changes

- `stock.picking._set_l10n_cl_purchase_order_reference()`, called from
  `sale.order.action_confirm()`: corrects the ODC reference to use
  `purchase_order_number`, or creates it when upstream built none.
- `account.move._set_l10n_cl_purchase_order_reference()`, called from
  `sale.order._create_invoices()`.
- README: new "Regional scope" section stating what each localization does. The
  manifest `summary` was empty; filled with the same idea.

Both guarded on `l10n_cl_reference_ids` being present, `account_fiscal_country_id ==
'CL'` and a configured `l10n_cl_dte_service_provider`, so nothing runs elsewhere. A
reference the user edited is never overwritten, and backorders keep the copy
`l10n_cl_edi_stock` makes.

### Why not in `_get_new_picking_values()`

`l10n_cl_edi_stock` sits above this module in the MRO (it depends on `l10n_cl_edi`,
this module only on `sale_stock`), so it runs first and overwrites
`values['l10n_cl_reference_ids']` after our `super()` call returns. Measured on a
real database:

```
l10n_cl_edi_stock.models.stock_picking        <- more derived
l10n_cl_edi.models.l10n_cl_edi_util
sale_require_purchase_order_number...
```

`stock.picking.create()` does not work either: `sale_id` is not resolved yet there, and
`purchase_order_number` is a non-stored compute that depends on it.

## Test plan

On a database with `l10n_cl`, `l10n_cl_edi`, `l10n_cl_edi_stock` and this module, on a
company with CL fiscal country and a DTE service provider set:

1. SO with `purchase_order_number` and **empty** "Your Reference" → confirm. The
   delivery has one ODC reference whose origin document number is the PO number
   (before: no reference at all).
2. SO with both fields → confirm. One ODC reference, holding the PO number, not
   `client_order_ref`.
3. Edit that reference by hand and re-run the method → the typed value is kept.
4. Invoice case 1 → the invoice carries the PO number and one ODC reference with it.
5. Re-run the method on the invoice → no duplicate.
6. Switch the company to AR and repeat → no Chilean reference is created, the field is
   still stored.

All six verified on Odoo 19.0 (14 assertions).