### PR TITLE
[IMP] pos_ux: install automatically with point_of_sale

### DIFF
--- a/pos_ux/README.rst
+++ b/pos_ux/README.rst
@@ -51,7 +51,8 @@ Installation
 
 To install this module, you need to:
 
-#. Only need to install the module
+#. Nothing, it is installed automatically together with Point of Sale
+   (``auto_install``).
 
 Configuration
 =============

--- a/pos_ux/__manifest__.py
+++ b/pos_ux/__manifest__.py
@@ -16,6 +16,6 @@
         ],
     },
     "installable": True,
-    "auto_install": False,
+    "auto_install": True,
     "license": "LGPL-3",
 }


### PR DESCRIPTION
`pos_ux` is recommended for every database that uses the Point of Sale, but it
had to be installed by hand: the manifest kept `auto_install` as `False`, as it
has been since 17.0 (16.0 did auto install it). This restores it on 19.0.

The module only depends on `point_of_sale` and carries nothing from the
Argentinian localization: no `l10n_ar`, no `l10n_latam`, no AFIP and no document
types. The only `l10n` hits in the code are the core translation import
(`@web/core/l10n/translation`), so auto installing it is also safe on the
Chilean and Uruguayan databases.

Heads-up for the review: with `auto_install` on, every database with the PoS
installed also gets the validations of this module, which make the intermediary
account and the outstanding account of the payment methods mandatory and block
opening the PoS while they are missing. Databases that use the PoS without
`pos_ux` today will need those accounts configured before the next session.

Scope is 19.0 only. Whether to do the same on master is still to be decided.

Task: https://www.adhoc.inc/odoo/project.task/73656

Test plan:
- On a database with `point_of_sale` installed, update the module list: `pos_ux`
  is installed on its own.
- Fresh database installing `point_of_sale`: `pos_ux` comes along with it.
