### PR TITLE
[FIX] sale_order_type_automation: invoice deliveries sent to inter-company transit

### DIFF
--- a/sale_order_type_automation/models/stock_picking.py
+++ b/sale_order_type_automation/models/stock_picking.py
@@ -14,7 +14,7 @@ class StockPicking(models.Model):
         """
         res = super()._action_done()
         sale_orders = (
-            self.filtered(lambda p: p.location_id.usage == "customer" or p.location_dest_id.usage == "customer")
+            self.filtered(lambda p: p.location_id._is_outgoing() or p.location_dest_id._is_outgoing())
             .sudo()
             .mapped("sale_id")
         )


### PR DESCRIPTION
## Qué pasa

`stock.picking._action_done` corría la automatización de facturación solo si
el remito tocaba una ubicación con uso `customer`. Cuando el cliente de la
orden de venta es el contacto de otra compañía de la misma base, Odoo entrega
contra la ubicación de tránsito intercompañía (`stock.stock_location_inter_company`),
así que esas órdenes quedaban afuera del filtro y la factura nunca se creaba,
ni siquiera en borrador — había que entrar a cada orden y usar "Crear factura".

La cantidad entregada sí se computa en ese caso: el core usa
`stock.location._is_outgoing()` (uso `customer` **o** hijo del tránsito
intercompañía) para decidir qué movimientos cuentan como entregados. El filtro
del módulo era más angosto que ese criterio.

## Qué cambia

Usar `_is_outgoing()` en vez del chequeo propio de `usage == "customer"`. Queda
alineado con el criterio del core: cubre el tránsito intercompañía y sigue
ignorando los pasos internos de la cadena (pick/pack).

## Test plan

Sobre una base con el problema, orden de venta con tipo que factura
automáticamente y cliente que es el contacto de otra compañía:

1. Confirmar la orden y validar el remito.
2. Antes del cambio: `invoice_status = "to invoice"` y `invoice_ids` vacío.
3. Con el cambio: la factura se crea sola (en borrador o validada, según
   `invoicing_atomation` y `background_post` del tipo de venta).

No regresión: con un cliente común (entrega a la ubicación de clientes) la
factura se sigue creando igual, y un movimiento interno no dispara nada.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/126924