### PR TITLE
[FIX] sale_stock_ux: auto-install broken by opt-in dependency

### DIFF
--- a/sale_stock_ux/__manifest__.py
+++ b/sale_stock_ux/__manifest__.py
@@ -54,6 +54,6 @@
     "demo": [],
     "test": [],
     "installable": True,
-    "auto_install": True,
+    "auto_install": ["sale_stock", "sale_ux", "stock_ux", "web"],
     "application": False,
 }


### PR DESCRIPTION
Task: https://www.adhoc.inc/odoo/project.task/73878

## Problem

`sale_stock_ux` declares `auto_install: True`, but on 19.0 it stopped installing
itself on new databases and had to be installed by hand.

The module gained a dependency on `product_stock_by_location`, needed by the
stock widget after it started filtering quants by
`location_id.show_stock_on_products`. That module is opt-in: `auto_install: False`.

With `auto_install: True` the core turns *every* entry of `depends` into a
required trigger (`odoo/modules/module.py`, `auto_install_required`), and an
auto-install module is only marked to install when all of its required triggers
are installed (`must_install` in `ir_module.py: button_install`, and the
equivalent query in `odoo/modules/db.py`). A single opt-in dependency is
therefore enough to disable the auto-install altogether, which is what happened
here. 18.0 does not carry that dependency and keeps auto-installing.

Measured over our production 19.0 databases: every database that has
`product_stock_by_location` also has `sale_stock_ux`, and the databases that
have `sale_stock` + `stock_ux` but not `sale_stock_ux` are exactly the ones
without it (38 out of 169). On 18.0 the module is present on 312 out of 313.

## Fix

Declare the auto-install triggers explicitly, leaving the new dependency out of
them. `product_stock_by_location` is still installed together with the module:
it stays a regular dependency, and `_state_update` marks every entry of
`dependencies_id` to install (`db.py` does the same when it auto-installs a
module).

No functional change: `stock.location.show_stock_on_products` defaults to `True`,
so a fresh install shows the stock as before.

## Test plan

- Install a database with Sales + Inventory and without
  `product_stock_by_location`: `sale_stock_ux` is installed automatically and
  brings `product_stock_by_location` with it.
- The manifest still satisfies the core assertion that the auto-install triggers
  are a subset of `depends`.

This does not retrofit databases that already exist: the core needs at least one
required trigger in state `to install` to fire the auto-install, so a database
created without the module still needs it installed once.
