### PR TITLE
[REF] sale_order_type_ux: drop downpayment account override, now in account_multicompany_ux

### DIFF
--- a/sale_order_type_ux/models/sale_order_line.py
+++ b/sale_order_type_ux/models/sale_order_line.py
@@ -11,27 +11,3 @@ class SaleOrderLine(models.Model):
     # Quitamos el check_company ya que no permitira
     # realizar un cambio de compañia entre la venta y su factura de anticipo
     tax_id = fields.Many2many(check_company=False)
-
-    def _prepare_invoice_line(self, **optional_values):
-        res = super()._prepare_invoice_line(**optional_values)
-        # Fix multicompañía:
-        # Cuando se cambia la compañía de una factura de anticipo (ya sea con el wizard de "change company"
-        # o mediante el sale order type), Odoo reutiliza la cuenta contable de esa factura de anticipo
-        # para las siguientes facturas.
-        # El problema es que el cambio de compañía recién se aplica al crear la factura en borrador,
-        # por lo que la cuenta tomada no coincide con la compañía actual (de la venta).
-        # Para evitarlo, se fuerza la cuenta que hubiera correspondido sin el cambio de compañía;
-        # luego, el wizard se encarga de ajustar las cuentas según corresponda.
-        downpayment_lines = self.invoice_lines.filtered("is_downpayment")
-        account_id = res.get("account_id") and self.env["account.account"].browse(res["account_id"]) or None
-        if (
-            self.is_downpayment
-            and downpayment_lines
-            and account_id
-            and self.company_id.id not in account_id.company_ids.ids
-        ):
-            account_id = self.env["account.change.company"]._get_change_downpayment_account(
-                self.company_id, self.invoice_lines, self.order_id.fiscal_position_id
-            )
-            res["account_id"] = account_id.id
-        return res


### PR DESCRIPTION
## What

`sale_order_type_ux` overrode `_prepare_invoice_line` to force the downpayment account of the order company on the invoice line. It is needed because `_create_invoices` creates the invoice in the order company and only afterwards moves it with the change company wizard, while `sale._prepare_invoice_line` copies the account of the already invoiced downpayment without checking its company.

That problem is not specific to sale order types: any database with more than one company hits it as soon as a downpayment invoice ends up in another company than its order, and databases without this module have no fix at all today.

## How

The guard now lives in `account_multicompany_ux` (ingadhoc/multi-company#320), which this module already depends on, so this copy is redundant and is removed.

Same target company (the order one) and same criterion (downpayment account of the product category, income account otherwise), with two intentional differences:

- the account is looked up on the line product first and on the order products only as a fallback;
- an account shared by a parent company is accepted instead of being replaced, which is what `_check_company` actually allows (`check_companies_domain_parent_of`).

The `check_company=False` relaxation on `tax_id` stays — it covers the taxes, not the account.

## Test plan

Depends on ingadhoc/multi-company#320: both branches share the name, so runbot builds them together and this module keeps its behaviour only with that one in.

1. Sale order type whose journal belongs to another company.
2. Sale order in company B with that type, confirmed.
3. Invoice → Down payment. The invoice is created in B and moved to A by the wizard. Post it.
4. Back on the order → Create invoice with "Deduct down payments".

The final invoice is created and the deduction line takes an account of the order company, same as before this change.

Internal ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/127169
