### PR TITLE
[FIX] sale_gathering_delivery: isolate multicompany tests from exception rules

### DIFF
--- a/sale_gathering_delivery/tests/test_sale_gathering_delivery_multicompany.py
+++ b/sale_gathering_delivery/tests/test_sale_gathering_delivery_multicompany.py
@@ -53,6 +53,14 @@ class TestSaleGatheringDeliveryMulticompany(AccountTestInvoicingCommon):
             "default_account_revenue"
         ]
 
+        # When sale_exception is installed, confirming an order that breaks an active rule raises
+        # BaseExceptionError instead of opening the popup (there is no web client to handle it here).
+        # Rules like "Reference Field Required" or "Unapproved Partner" are active by default, so the
+        # orders built below would never reach action_confirm.
+        sale_exception_installed = cls.env["sale.order"]._fields.get("ignore_exception")
+        if sale_exception_installed:
+            cls.env["exception.rule"].search([("active", "=", True)]).write({"active": False})
+
     def _create_gathering_order(self, sale_type=False):
         order_values = {
             "partner_id": self.partner_a.id,


### PR DESCRIPTION
## Problema

En el build `[18.0] All` de runbot, los dos tests de
`sale_gathering_delivery/tests/test_sale_gathering_delivery_multicompany.py` terminan en error:

```
File ".../sale_gathering_delivery/tests/test_sale_gathering_delivery_multicompany.py", line 88, in _create_gathering_order
    so.action_confirm()
...
File ".../sale_exception/models/sale_order.py", line 19, in detect_exceptions
File ".../base_exception/models/base_exception_method.py", line 119, in detect_exceptions
    raise BaseExceptionError(
odoo.addons.base_exception.exceptions.BaseExceptionError: {"src_model": "sale.order", "target_model": "sale.order"}
```

Los tests crean la orden desde cero (sin `client_order_ref` y con el partner en su estado por
default), así que en una base con todo el bundle instalado incumplen alguna `exception.rule`
activa —`sale_require_ref` y la de partner no aprobado vienen activas por default—.
`base_exception` levanta `BaseExceptionError` para rollbackear y que el web client abra el
wizard; fuera de un request HTTP eso es error duro y el test nunca llega a lo que quiere probar.

## Cambio

En el `setUpClass`, si `sale_exception` está instalado, se desactivan las reglas activas — el
mismo patrón que ya usa `sale_gathering/tests/common.py`. El `write` se rollbackea junto con la
transacción de la clase, así que no ensucia la base para el resto de la suite.

No cambia comportamiento de producto: es aislamiento de los tests.

## Test plan

- `sale_gathering_delivery` en un build con el bundle completo (el mismo trigger donde falla hoy):
  `TestSaleGatheringDeliveryMulticompany.test_change_company_advance_invoice` y
  `test_delivery_line_created_after_invoice_company_change` en verde.
- El resto de la suite de `sale_gathering_delivery` y `sale_gathering` sin cambios.

Ticket interno: https://www.adhoc.inc/odoo/helpdesk.ticket/127586