### PR TITLE
[FIX] sale_stock_ux: forecast report crash on another salesman's sale order

### DIFF
--- a/sale_stock_ux/models/__init__.py
+++ b/sale_stock_ux/models/__init__.py
@@ -6,3 +6,4 @@ from . import stock_move
 from . import sale_order
 from . import sale_order_line
 from . import stock_rule
+from . import stock_forecasted

--- a/sale_stock_ux/models/stock_forecasted.py
+++ b/sale_stock_ux/models/stock_forecasted.py
@@ -1,0 +1,34 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models
+
+
+class StockForecasted(models.AbstractModel):
+    _inherit = "stock.forecasted_product_product"
+
+    def _prepare_report_line(
+        self,
+        quantity,
+        move_out=None,
+        move_in=None,
+        replenishment_filled=True,
+        product=False,
+        reserved_move=False,
+        in_transit=False,
+        read=True,
+    ):
+        """`sale_stock` lee la OV del remito sin sudo y el pronosticado revienta si es de otro vendedor.
+
+        Pasa con cualquier movimiento saliente sin `sale_line_id` cuyo remito sí
+        tenga OV (una línea agregada a mano al remito, por ejemplo): ahí el
+        `sudo()` de `_get_source_document` no llega a traer la OV a la caché y
+        `sale_stock` la lee con el usuario. La traemos nosotros con sudo, que es
+        lo que el reporte ya hace con el resto de los datos de la OV. Ticket 127167.
+        """
+        if read and move_out and move_out.picking_id.sale_id:
+            move_out.picking_id.sale_id.sudo().read(["amount_untaxed", "currency_id", "partner_id"])
+        return super()._prepare_report_line(
+            quantity, move_out, move_in, replenishment_filled, product, reserved_move, in_transit, read
+        )

--- a/sale_stock_ux/tests/__init__.py
+++ b/sale_stock_ux/tests/__init__.py
@@ -3,3 +3,4 @@ from . import test_kit_return_uom
 from . import test_return_of_return
 from . import test_stock_info_batching
 from . import test_invoice_status_return
+from . import test_forecast_other_salesman

--- a/sale_stock_ux/tests/test_forecast_other_salesman.py
+++ b/sale_stock_ux/tests/test_forecast_other_salesman.py
@@ -1,0 +1,91 @@
+from odoo import Command
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestForecastOtherSalesman(TransactionCase):
+    """El pronosticado de un producto no debe romper por una OV de otro vendedor.
+
+    Un vendedor con "solo mostrar documentos propios" abría el pronosticado y le
+    saltaba un AccessError sobre `sale.order`: `sale_stock` lee monto, moneda y
+    cliente de la OV del remito sin sudo. Solo se manifiesta cuando el movimiento
+    saliente no tiene `sale_line_id` (una línea agregada a mano al remito), porque
+    ahí el `sudo()` de `_get_source_document` no trae la OV a la caché. Ticket 127167.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.warehouse = self.env["stock.warehouse"].search([("company_id", "=", self.env.company.id)], limit=1)
+        self.customer_location = self.env.ref("stock.stock_location_customers")
+        self.partner = self.env["res.partner"].create({"name": "Cliente pronosticado", "customer_rank": 1})
+        self.product_so = self._make_product("Producto de la OV")
+        self.product_manual = self._make_product("Producto agregado al remito")
+        self.salesman_a = self._make_salesman("salesman_a_127167")
+        self.salesman_b = self._make_salesman("salesman_b_127167")
+
+    def _make_product(self, name):
+        return self.env["product.product"].create({"name": name, "type": "consu", "is_storable": True})
+
+    def _make_salesman(self, login):
+        return self.env["res.users"].create(
+            {
+                "name": login,
+                "login": login,
+                "company_id": self.env.company.id,
+                "company_ids": [Command.set([self.env.company.id])],
+                "groups_id": [
+                    Command.link(self.env.ref("sales_team.group_sale_salesman").id),
+                    Command.link(self.env.ref("stock.group_stock_user").id),
+                ],
+            }
+        )
+
+    def test_forecast_with_move_without_sale_line(self):
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "user_id": self.salesman_a.id,
+                "warehouse_id": self.warehouse.id,
+                "order_line": [Command.create({"product_id": self.product_so.id, "product_uom_qty": 3})],
+            }
+        )
+        # El remito se arma a mano en lugar de confirmar la orden: así el caso no
+        # depende de las excepciones de venta ni de las rutas de la base.
+        group = self.env["procurement.group"].create({"name": order.name, "sale_id": order.id})
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.warehouse.out_type_id.id,
+                "partner_id": self.partner.id,
+                "location_id": self.warehouse.lot_stock_id.id,
+                "location_dest_id": self.customer_location.id,
+                "group_id": group.id,
+            }
+        )
+        move = self.env["stock.move"].create(
+            {
+                "name": self.product_manual.name,
+                "picking_id": picking.id,
+                "product_id": self.product_manual.id,
+                "product_uom_qty": 2,
+                "location_id": picking.location_id.id,
+                "location_dest_id": picking.location_dest_id.id,
+                "company_id": picking.company_id.id,
+                "group_id": group.id,
+            }
+        )
+        picking.action_confirm()
+        self.assertEqual(picking.sale_id, order)
+        self.assertFalse(move.sale_line_id)
+
+        self.assertFalse(order.with_user(self.salesman_b).has_access("read"))
+
+        # La caché tiene la OV cargada como superusuario; sin invalidar no se ejerce la regla.
+        self.env.invalidate_all()
+        report = (
+            self.env["stock.forecasted_product_product"]
+            .with_user(self.salesman_b)
+            .with_context(warehouse=self.warehouse.id)
+        )
+        lines = report.get_report_values(docids=self.product_manual.ids)["docs"]["lines"]
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0]["move_out"]["picking_id"]["sale_id"]["id"], order.id)


### PR DESCRIPTION
## Qué pasa

`sale_stock` lee `amount_untaxed`, la moneda y el contacto de la orden de venta del remito sin `sudo()` en `_prepare_report_line`. Casi nunca se nota, porque `stock` llama antes a `move_out.sudo()._get_source_document()` y esa lectura ya deja la orden en la caché de la transacción: cuando `sale_stock` la vuelve a leer, la regla de registro no se ejerce.

Falla cuando el movimiento saliente **no tiene `sale_line_id`** y el remito sí tiene orden de venta — por ejemplo, una línea agregada a mano al remito. Ahí `_get_source_document()` devuelve el remito, la orden nunca entra a la caché, y un vendedor con el permiso "solo mostrar documentos propios" recibe un `AccessError` sobre `sale.order` que voltea el pronosticado entero, para cualquier producto y almacén involucrados en ese remito.

Está igual en 18.0 y en 19.0 del core.

## Qué cambia

Override de `_prepare_report_line` en `sale_stock_ux` que trae la orden de venta del remito con `sudo()` antes de que `sale_stock` la lea. Es lo que el reporte ya hace con el resto de los datos de la orden: `_get_source_document()` en `stock` y los presupuestos de `_get_report_header()` en `sale_stock` también van con `sudo()`.

## Cómo se prueba

`sale_stock_ux/tests/test_forecast_other_salesman.py`: confirma una orden de venta de un vendedor, le agrega a mano al remito un movimiento de otro producto (queda sin `sale_line_id`), y abre el pronosticado de ese producto con un segundo vendedor restringido a sus propios documentos. Sin el override, el test corta con `AccessError`.

Ref: https://www.adhoc.inc/odoo/helpdesk.ticket/127167