### PR TITLE
[FIX] sale_gathering: reference gathering only on gathering down payments

### DIFF
--- a/sale_gathering/wizards/sale_advance_payment_inv.py
+++ b/sale_gathering/wizards/sale_advance_payment_inv.py
@@ -53,7 +53,11 @@ class SaleAdvancePaymentInvWizard(models.TransientModel):
                 )
 
     def _create_invoices(self, sale_orders):
-        invoice = super()._create_invoices(sale_orders)
-        if invoice.invoice_line_ids.filtered("is_downpayment"):
-            invoice.write({"ref": "Acopio"})
-        return invoice
+        invoices = super()._create_invoices(sale_orders)
+        gathering_invoices = invoices.filtered(
+            lambda move: move.invoice_line_ids.filtered(
+                lambda line: line.is_downpayment and line.sale_line_ids.order_id.filtered("is_gathering")
+            )
+        )
+        gathering_invoices.write({"ref": "Acopio"})
+        return invoices


### PR DESCRIPTION
### Qué pasaba

Con `sale_gathering` instalado, **cualquier** factura de anticipo salía con la referencia del cliente en `Acopio`, fuera o no de acopio la orden de venta. Como la referencia forma parte del display name de la factura, también se veía en el breadcrumb (`Draft Invoice (Acopio)`).

El override de `sale.advance.payment.inv._create_invoices` condicionaba el `write` a que la factura tuviera alguna línea con `is_downpayment`, que es el flag estándar de Odoo para anticipos y no dice nada sobre acopios.

### Qué cambia

La referencia se escribe solo en las facturas cuyas líneas de anticipo vienen de una orden con `is_gathering`, mismo criterio que el módulo ya usa en `models/account_move.py`. Además se evalúa por factura, porque con facturación consolidada `super()` puede devolver más de una y antes se escribía sobre todo el recordset.

### Cómo probarlo

Con el módulo instalado:

1. Orden de venta común → *Crear factura* → anticipo por porcentaje o monto fijo. La referencia del cliente tiene que quedar **vacía**.
2. Orden de acopio → factura de acopio. La referencia tiene que decir **Acopio**.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/127726